### PR TITLE
Enable idm module in dnf to install ipa

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ The following table lists the supported devices managed by Omnia. Other devices 
 
 Device type	|	Supported models	
 -----------	|	-------	
-Dell EMC PowerEdge Servers	|	PowerEdge C4140, C6420, R240, R340, R440, R540, R640, R740, R740xd, R740xd2, R840, R940, R940xa
+Dell EMC PowerEdge Servers	|	PowerEdge C4140, C6420, C6520, R240, R340, R440, R540, R640, R650, R740, R740xd, R740xd2, R750, R750xa, R840, R940, R940xa
 Dell EMC PowerVault Storage	|	PowerVault ME4084, ME4024, and ME4012 Storage Arrays
 Dell EMC Networking Switches	|	PowerSwitch S3048-ON and PowerSwitch S5232F-ON
 Mellanox InfiniBand Switches	|	NVIDIA MQM8700-HS2F Quantum HDR InfiniBand Switch 40 QSFP56

--- a/roles/login_common/tasks/enable_dnf_module.yml
+++ b/roles/login_common/tasks/enable_dnf_module.yml
@@ -13,10 +13,9 @@
 #  limitations under the License.
 ---
 
-- name: Add ports of manager and login node to firewall
-  include_tasks: firewall_settings.yml
-  when: hostvars['127.0.0.1']['login_node_required']
-
 - name: Enable module idm in Rocky or Centos >= 8.0
-  include_tasks: enable_dnf_module.yml
-  when: hostvars['127.0.0.1']['login_node_required']
+  command: dnf module enable idm:DL1 -y
+  when:
+    - ( ansible_distribution | lower == os_centos ) or
+      ( ansible_distribution | lower == os_rocky )
+    - ( ansible_distribution_version >= os_version )

--- a/roles/login_common/vars/main.yml
+++ b/roles/login_common/vars/main.yml
@@ -30,3 +30,8 @@ dns_port1: "53/tcp"
 dns_port2: "53/udp"
 dt_port1: "7389/tcp"
 ntp_port1: "123/udp"
+
+# Usage: enable_dnf_module.yml
+os_centos: 'centos'
+os_rocky: 'rocky'
+os_version: '8.0'


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Fixes #627 

### Description of the Solution
Enabled module idm in dnf for Rocky 8.4 and CentOS versions > 8.0

### Suggested Reviewers
@lwilson @j0hnL 
