### PR TITLE
Defect fix for software_update.yml ensuring image availability is enforced and visible during software update flow.

### DIFF
--- a/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
+++ b/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
@@ -46,7 +46,7 @@
       loop: "{{ images_to_pull }}"
       loop_control:
         label: "{{ item }}"
-      changed_when: "'downloaded' in pull_result.stdout | lower or pull_result.rc == 0"
+      changed_when: "pull_result.rc == 0"
       failed_when: false
       when: nerdctl_installed and images_to_pull | length > 0
 

--- a/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
+++ b/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
@@ -11,6 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+#  Copyright 2025 Dell Inc.
+#  Licensed under the Apache License, Version 2.0
+
 ---
 
 - name: Pull images to node
@@ -22,12 +25,20 @@
       ansible.builtin.command: "which nerdctl"
       register: nerdctl_check
       delegate_to: "{{ target_node }}"
-      changed_when: true
+      changed_when: false
       ignore_errors: true
 
     - name: Set nerdctl_installed fact
       ansible.builtin.set_fact:
         nerdctl_installed: "{{ nerdctl_check.rc == 0 }}"
+
+    - name: Show warning if nerdctl is not installed on {{ target_node }}
+      ansible.builtin.debug:
+        msg:
+          - "[WARNING] nerdctl not found on {{ target_node }}."
+          - "To enable container image pulling, run the 'scheduler.yml' playbook to install 'nerdctl'."
+          - "The playbook execution will proceed but image pulling will be skipped on this node."
+      when: not nerdctl_installed
 
     - name: Set images to pull for group {{ current_group_name }}
       ansible.builtin.set_fact:
@@ -35,8 +46,25 @@
 
     - name: Pull image using nerdctl on {{ target_node }}
       ansible.builtin.command: "nerdctl pull {{ item }}"
+      register: pull_result
       delegate_to: "{{ target_node }}"
-      changed_when: true
-      failed_when: false
       loop: "{{ images_to_pull }}"
+      loop_control:
+        label: "{{ item }}"
+      changed_when: "'Downloaded' in pull_result.stdout or pull_result.rc == 0"
+      failed_when: false
       when: nerdctl_installed and images_to_pull | length > 0
+
+    - name: Collect failed image pulls
+      ansible.builtin.set_fact:
+        failed_images: >-
+          {{ pull_result.results | default([])
+             | selectattr('rc', 'defined')
+             | selectattr('rc', 'ne', 0)
+             | map(attribute='item')
+             | list }}
+
+    - name: Fail if any image pulls failed on {{ target_node }}
+      ansible.builtin.fail:
+        msg: "[FAILED IMAGE PULLS] The following images failed to pull on {{ target_node }}:\n  {{ failed_images | join(', ') }}"
+      when: failed_images | length > 0

--- a/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
+++ b/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
@@ -32,10 +32,7 @@
 
     - name: Show warning if nerdctl is not installed on {{ target_node }}
       ansible.builtin.debug:
-        msg:
-          - "[WARNING] nerdctl not found on {{ target_node }}."
-          - "To enable container image pulling, run the 'scheduler.yml' playbook to install 'nerdctl'."
-          - "The playbook execution will proceed but image pulling will be skipped on this node."
+        msg: "{{ nerdctl_not_found_warning }}"
       when: not nerdctl_installed
 
     - name: Set images to pull for group {{ current_group_name }}
@@ -49,7 +46,7 @@
       loop: "{{ images_to_pull }}"
       loop_control:
         label: "{{ item }}"
-      changed_when: "'Downloaded' in pull_result.stdout or pull_result.rc == 0"
+      changed_when: "'downloaded' in pull_result.stdout | lower or pull_result.rc == 0"
       failed_when: false
       when: nerdctl_installed and images_to_pull | length > 0
 
@@ -64,5 +61,5 @@
 
     - name: Fail if any image pulls failed on {{ target_node }}
       ansible.builtin.fail:
-        msg: "[FAILED IMAGE PULLS] The following images failed to pull on {{ target_node }}:\n  {{ failed_images | join(', ') }}"
+        msg: "{{ failed_image_pull_msg }}"
       when: failed_images | length > 0

--- a/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
+++ b/utils/software_update/roles/software_update/tasks/pull_images_to_node.yml
@@ -11,8 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  Copyright 2025 Dell Inc.
-#  Licensed under the Apache License, Version 2.0
 
 ---
 

--- a/utils/software_update/roles/software_update/vars/main.yml
+++ b/utils/software_update/roles/software_update/vars/main.yml
@@ -46,3 +46,12 @@ Please check packages {{ hostvars['localhost']['package_list'] }} are available 
 # Usage: package_installation_softwares_list.yml
 softwares_list_install_fail_msg: "Failed. Package installation failed for packages mentioned in softwares_list: {{ software }}.
 Please check packages mentioned for software {{ software }} in software_update_config.yml are available to install with repos configured in the nodes."
+
+# Usage: pull_images_to_node.yml
+nerdctl_not_found_warning: |
+  [WARNING] nerdctl not found on {{ target_node }}.
+  To enable container image pulling, run the 'scheduler.yml' playbook to install 'nerdctl'.
+  The playbook execution will proceed but image pulling will be skipped on this node.
+
+failed_image_pull_msg: "[FAILED IMAGE PULLS] The following images failed to pull on {{ target_node }}:\n  {{ failed_images | join(', ') }}"
+

--- a/utils/software_update/roles/software_update/vars/main.yml
+++ b/utils/software_update/roles/software_update/vars/main.yml
@@ -54,4 +54,3 @@ nerdctl_not_found_warning: |
   The playbook execution will proceed but image pulling will be skipped on this node.
 
 failed_image_pull_msg: "[FAILED IMAGE PULLS] The following images failed to pull on {{ target_node }}:\n  {{ failed_images | join(', ') }}"
-


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Defect fix: Software_update.yml
If images are not available in local repo, then software_update.yml playbook will fail.
Modified code to :
- Collect images that failed to pull using nerdctl.
- Displays failed image list per node.
- Fails the playbook when any image fails to download.
- Improved warning when nerdctl is missing (execution continues).



### Suggested Reviewers

