### PR TITLE
add task to fetch BeeGFS client version

### DIFF
--- a/storage/roles/storage_validation/tasks/fetch_software_config.yml
+++ b/storage/roles/storage_validation/tasks/fetch_software_config.yml
@@ -39,6 +39,17 @@
   ansible.builtin.set_fact:
     nfs_support: "{{ software_config.softwares | selectattr('name', 'equalto', 'nfs') | list | length > 0 }}"
 
+- name: Fetch beegfs version
+  when: beegfs_support
+  block:
+    - name: Extract beegfs version
+      ansible.builtin.set_fact:
+        beegfs_client_version: "{{ software_config.softwares | selectattr('name', 'equalto', 'beegfs') | map(attribute='version') | first }}"
+  rescue:
+    - name: Unable to fetch beegfs version
+      ansible.builtin.fail:
+        msg: "{{ beegfs_version_fail_msg }}"
+
 - name: Validate beegfs repo incase of always
   when: beegfs_support and repo_config == "always" and cluster_os_type in ["rhel","rocky"]
   block:


### PR DESCRIPTION
### Issues Resolved by this Pull Request
The storage.yml playbook failed during the task "Check beegfs repo configured in pulp" because beegfs_client_version was undefined. So added a task to collect the beegfs_client version.

Fixes #

### Description of the Solution
This PR introduces a task to fetch the BeeGFS version from software_config json, and sets it using set_fact.

### Suggested Reviewers
@abhishek-sa1 @priti-parate @snarthan Please review
