### PR TITLE
omnia share path validation

### DIFF
--- a/omnia.sh
+++ b/omnia.sh
@@ -330,7 +330,7 @@ init_container_config() {
 
             # Check if the Omnia shared path is absolute path and path exists.
             if [[ "$omnia_path" != /* ]] || [ ! -d "$omnia_path" ]; then
-                echo -e "${RED} Omnia shared path is not an absolute path or does not exist! Please re-run omnia.sh --install with valid Omnia shared path${NC}"
+                echo -e "${RED} Omnia shared path is not an absolute path or does not exist! Please re-run omnia.sh --install with valid Omnia shared path.${NC}"
                 exit 1
             fi
             ;;
@@ -347,6 +347,13 @@ init_container_config() {
 
                         echo -e "${BLUE} Please provide the OIM client share path (mount target):${NC}"
                         read -p "Omnia shared path: " omnia_path
+
+                        # Validate Omnia shared path is absolute
+                        if [[ "$omnia_path" != /* ]]; then
+                            echo -e "${RED}Omnia shared path must be an absolute path.${NC}"
+                            exit 1
+                        fi
+
                         nfs_type="external"
                         break
                         ;;


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
When running omnia.sh in NFS mode, if a user provided a relative path for the Omnia share path, the script failed to bring up the Omnia core container. The error displayed was unclear and did not indicate that the problem was due to using a relative path. As a fix, A validation check was added to ensure the Omnia share path is an absolute path. If a relative path is provided, the script now fails immediately with a clear error message.

### Suggested Reviewers
@abhishek-sa1 @priti-parate 