### PR TITLE
login_compiler slurm.conf changes

### DIFF
--- a/discovery/roles/slurm_config/templates/slurm.conf.j2
+++ b/discovery/roles/slurm_config/templates/slurm.conf.j2
@@ -32,8 +32,9 @@ NodeName={{ cmpt }}{% for k in node_params[cmpt] %} {{ k }}={{ node_params[cmpt]
 {% else %}
 NodeName=localhost State=UNKNOWN
 {% endfor %}
-{% for login in (login_list | default([])) %}
-NodeName={{ login }}
+{% set all_login_nodes = (login_list | default([])) + (compiler_login_list | default([])) %}
+{% for login_node in all_login_nodes %}
+NodeName={{ login_node }}
 {% endfor %}
 
 # PARTITION INFO


### PR DESCRIPTION
### Issues Resolved by this Pull Request
Please be sure to associate your pull request with one or more open issues. Use the word _Fixes_ as well as a hashtag (_#_) prior to the issue number in order to automatically resolve associated issues (e.g., _Fixes #100_).

Fixes #

### Description of the Solution
On the login compiler node, slurmd previously failed because the node name was missing in the slurm.conf file. So, updated the template to include logic that automatically adds the login compiler node to the slurm.conf file.

### Suggested Reviewers
@abhishek-sa1 @priti-parate Please Review
