### PR TITLE
login compiler changes with pmix support

### DIFF
--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -184,7 +184,7 @@
 
           # Check Slurm
           if sinfo >/dev/null 2>&1; then
-            SLURM_FLAG="--with-slurm=yes"
+            SLURM_FLAG="--with-slurm=yes --with-munge=/usr"
           else
             SLURM_FLAG="--with-slurm=no"
           fi

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -184,7 +184,7 @@
 
           # Check Slurm
           if sinfo >/dev/null 2>&1; then
-            SLURM_FLAG="--with-slurm=yes"
+            SLURM_FLAG="--with-slurm=yes --with-munge=/usr"
           else
             SLURM_FLAG="--with-slurm=no"
           fi

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -150,3 +150,11 @@
         - systemctl restart sshd
 
 {% endif %}
+
+{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
+        # Add NFS entry and mount
+        - mkdir -p {{ client_mount_path }}
+        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - mount -a
+{% endif %}
+

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -157,4 +157,3 @@
         - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 {% endif %}
-

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -150,3 +150,10 @@
         - systemctl restart sshd
 
 {% endif %}
+
+{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
+        # Add NFS entry and mount
+        - mkdir -p {{ client_mount_path }}
+        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - mount -a
+{% endif %}

--- a/input/config/aarch64/rhel/10.0/slurm_custom.json
+++ b/input/config/aarch64/rhel/10.0/slurm_custom.json
@@ -2,8 +2,11 @@
     "slurm_custom": {
         "cluster": [
             {"package": "munge", "type": "rpm", "repo_name": "aarch64_appstream"},
+            {"package": "munge-devel", "type": "rpm", "repo_name": "aarch64_codeready-builder"},
             {"package": "firewalld", "type": "rpm", "repo_name": "aarch64_baseos"},
-            {"package": "python3-firewall", "type": "rpm", "repo_name": "aarch64_baseos"}
+            {"package": "python3-firewall", "type": "rpm", "repo_name": "aarch64_baseos"},
+            {"package": "pmix", "type": "rpm", "repo_name": "aarch64_appstream"},
+            {"package": "pmix-devel", "type": "rpm", "repo_name": "aarch64_appstream"}
         ]
     },
     "slurm_control_node": {

--- a/input/config/x86_64/rhel/10.0/slurm_custom.json
+++ b/input/config/x86_64/rhel/10.0/slurm_custom.json
@@ -2,8 +2,11 @@
     "slurm_custom": {
         "cluster": [
             {"package": "munge", "type": "rpm", "repo_name": "x86_64_appstream"},
+            {"package": "munge-devel", "type": "rpm", "repo_name": "x86_64_codeready-builder"},
             {"package": "firewalld", "type": "rpm", "repo_name": "x86_64_baseos"},
-            {"package": "python3-firewall", "type": "rpm", "repo_name": "x86_64_baseos"}
+            {"package": "python3-firewall", "type": "rpm", "repo_name": "x86_64_baseos"},
+            {"package": "pmix", "type": "rpm", "repo_name": "x86_64_appstream"},
+            {"package": "pmix-devel", "type": "rpm", "repo_name": "x86_64_appstream"}
         ]
     },
     "slurm_control_node": {


### PR DESCRIPTION
### Description of the Solution
Updated scripts to mount OpenMPI and UCX binaries on the Slurm worker nodes.
Reason: Even when programs are compiled on the login/compiler node, running them via Slurm requires the OpenMPI and UCX binaries to be present on the worker nodes.
Added the munge-devel package in the local repo to provide the necessary headers and libraries required for OpenMPI compilation.

### Suggested Reviewers
@snarthan Please review
