### PR TITLE
Fix for generating the sampler file on slurm share when k8s and slurm shares both are present

### DIFF
--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_aarch64.yaml.j2
@@ -151,10 +151,10 @@
 
 {% endif %}
 
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
+{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] or hostvars['localhost']['ldms_support'] %}
         # Add NFS entry and mount
         - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 {% endif %}
 
@@ -223,11 +223,6 @@
 
 {% if hostvars['localhost']['ldms_support'] %}
         - echo " Starting LDMS setup " | tee -a /var/log/ldms-cloudinit.log
-
-        # Add NFS entry and mount
-        - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -a
 
         - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/
 

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_compiler_node_x86_64.yaml.j2
@@ -151,10 +151,10 @@
 
 {% endif %}
 
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
+{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] or hostvars['localhost']['ldms_support'] %}
         # Add NFS entry and mount
         - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 {% endif %}
 
@@ -223,11 +223,6 @@
 
 {% if hostvars['localhost']['ldms_support'] %}
         - echo " Starting LDMS setup " | tee -a /var/log/ldms-cloudinit.log
-
-        # Add NFS entry and mount
-        - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -a
 
         - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/
 

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_aarch64.yaml.j2
@@ -158,7 +158,7 @@
 
         # Add NFS entry and mount
         - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 
         - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-login_node_x86_64.yaml.j2
@@ -157,7 +157,7 @@
 
         # Add NFS entry and mount
         - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 
         - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_control_node_x86_64.yaml.j2
@@ -203,7 +203,7 @@
 
          # Add NFS entry and mount
          - mkdir -p {{ client_mount_path }}
-         - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+         - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
          - mount -a
 
          - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_aarch64.yaml.j2
@@ -159,20 +159,15 @@
 
 {% endif %}
 
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
+{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] or hostvars['localhost']['ldms_support'] %}
         # Add NFS entry and mount
         - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 {% endif %}
 
 {% if hostvars['localhost']['ldms_support'] %}
         - echo " Starting LDMS setup " | tee -a /var/log/ldms-cloudinit.log
-
-        # Add NFS entry and mount
-        - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -a
 
         - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/
 

--- a/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
+++ b/discovery/roles/configure_ochami/templates/cloud_init/ci-group-slurm_node_x86_64.yaml.j2
@@ -159,20 +159,15 @@
 
 {% endif %}
 
-{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] %}
+{% if hostvars['localhost']['ucx_support'] or hostvars['localhost']['openmpi_support'] or hostvars['localhost']['ldms_support'] %}
         # Add NFS entry and mount
         - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
+        - echo "{{ cloud_init_slurm_nfs_path }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
         - mount -a
 {% endif %}
 
 {% if hostvars['localhost']['ldms_support'] %}
         - echo " Starting LDMS setup " | tee -a /var/log/ldms-cloudinit.log
-
-        # Add NFS entry and mount
-        - mkdir -p {{ client_mount_path }}
-        - echo "{{ nfs_src }} {{ client_mount_path }} nfs defaults,_netdev 0 0" >> /etc/fstab
-        - mount -a
 
         - cp -rf {{ client_mount_path }}/ldms/samplers/sampler.conf /opt/ovis-ldms/etc/ldms/
 

--- a/discovery/roles/configure_ochami/templates/ldms/ldms_conf.sh.j2
+++ b/discovery/roles/configure_ochami/templates/ldms/ldms_conf.sh.j2
@@ -34,6 +34,12 @@ else
     echo "Service file not found: /opt/ovis-ldms/etc/systemd/system/ldmsd.sampler.service" | tee -a "$LOG_FILE"
 fi
 
+# Configure firewall safely
+
+echo "Configuring firewall for LDMS port 10001..." | tee -a "$LOG_FILE"
+sudo firewall-cmd --permanent --add-port=10001/tcp
+sudo firewall-cmd --reload
+
 # --- Verify LDMS connection and metrics ---
 echo "Verifying LDMS connection and metrics..." | tee -a "$LOG_FILE"
 /opt/ovis-ldms/sbin/ldms_ls -a ovis -A conf=/opt/ovis-ldms/etc/ldms/ldmsauth.conf -p 10001 -h localhost | tee -a "$LOG_FILE"

--- a/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
+++ b/discovery/roles/slurm_config/tasks/create_slurm_dir.yml
@@ -208,3 +208,8 @@
   ansible.builtin.set_fact:
     cloud_init_nfs_path_openldap: "{{ nfs_server_ip }}:{{ nfs_server_path }}/openldap"
   when: hostvars['localhost']['openldap_support']
+
+# This will be mounted for ucx, openmpi and ldms configurations on slurm nodes
+- name: NFS path for ucx, openmpi and ldms cloud init
+  ansible.builtin.set_fact:
+    cloud_init_slurm_nfs_path: "{{ nfs_server_ip }}:{{ nfs_server_path }}"


### PR DESCRIPTION
Fix for generating the sampler file on slurm share when k8s and slurm shares both are present