### PR TITLE
Fix for upgrade Fails Due to Missing Vault Password File .local_repo_credentials_key During Credential Decryption

### DIFF
--- a/upgrade/roles/import_input_parameters/tasks/restore_user_registry_credential.yml
+++ b/upgrade/roles/import_input_parameters/tasks/restore_user_registry_credential.yml
@@ -15,17 +15,17 @@
 
 - name: Check if backup user_registry_credential.yml exists
   ansible.builtin.stat:
-    path: "{{ backup_location }}/user_registry_credential.yml"
+    path: "{{ backup_location }}/{{ user_registry_file_name }}"
   register: backup_user_registry_credential_stat
 
 - name: Check if user_registry_credential.yml exists in current directory
   ansible.builtin.stat:
-    path: "{{ input_project_dir }}/user_registry_credential.yml"
+    path: "{{ input_project_dir }}/{{ user_registry_file_name }}"
   register: user_registry_credential_stat
 
 - name: Check if backup local_repo_credentials_key exists
   ansible.builtin.stat:
-    path: "{{ backup_location }}/.local_repo_credentials_key"
+    path: "{{ backup_location }}/{{ user_registry_key_name }}"
   register: backup_local_repo_credentials_key_stat
 
 - name: Add warning for missing user_registry_credential.yml to list
@@ -38,7 +38,7 @@
 
 - name: Check if backup file is encrypted
   ansible.builtin.command:
-    cmd: cat "{{ backup_location }}/user_registry_credential.yml"
+    cmd: cat "{{ backup_location }}/{{ user_registry_file_name }}"
   register: backup_user_registry_content
   changed_when: false
   failed_when: false
@@ -57,27 +57,23 @@
       block:
         - name: Copy encrypted user_registry_credential.yml from backup
           ansible.builtin.copy:
-            src: "{{ backup_location }}/user_registry_credential.yml"
-            dest: "{{ input_project_dir }}/user_registry_credential.yml"
-            mode: '0600'
+            src: "{{ backup_location }}/{{ user_registry_file_name }}"
+            dest: "{{ input_project_dir }}/{{ user_registry_file_name }}"
+            mode: "{{ user_registry_file_mode }}"
             force: true
             remote_src: true
 
         - name: Copy local_repo_credentials_key from backup
           ansible.builtin.copy:
-            src: "{{ backup_location }}/.local_repo_credentials_key"
-            dest: "{{ input_project_dir }}/.local_repo_credentials_key"
-            mode: '0600'
+            src: "{{ backup_location }}/{{ user_registry_key_name }}"
+            dest: "{{ input_project_dir }}/{{ user_registry_key_name }}"
+            mode: "{{ user_registry_key_mode }}"
             force: true
             remote_src: true
 
         - name: Display success message for encrypted file restoration
           ansible.builtin.debug:
-            msg: |
-              user_registry_credential.yml restored from backup.
-              Backup: {{ backup_location }}/user_registry_credential.yml
-              Target: {{ input_project_dir }}/user_registry_credential.yml
-              Status: Encrypted (key file also restored)
+            msg: "{{ msg_user_registry_encrypted_success }}"
       rescue:
         - name: Fail with decryption error message
           ansible.builtin.fail:
@@ -105,25 +101,25 @@
       block:
         - name: Copy local_repo_credentials_key from backup (unencrypted case)
           ansible.builtin.copy:
-            src: "{{ backup_location }}/.local_repo_credentials_key"
-            dest: "{{ input_project_dir }}/.local_repo_credentials_key"
-            mode: '0600'
+            src: "{{ backup_location }}/{{ user_registry_key_name }}"
+            dest: "{{ input_project_dir }}/{{ user_registry_key_name }}"
+            mode: "{{ user_registry_key_mode }}"
             force: true
             remote_src: true
 
         - name: Copy user_registry_credential.yml from backup (unencrypted)
           ansible.builtin.copy:
-            src: "{{ backup_location }}/user_registry_credential.yml"
-            dest: "{{ input_project_dir }}/user_registry_credential.yml"
-            mode: '0600'
+            src: "{{ backup_location }}/{{ user_registry_file_name }}"
+            dest: "{{ input_project_dir }}/{{ user_registry_file_name }}"
+            mode: "{{ user_registry_file_mode }}"
             force: true
             remote_src: true
 
         - name: Encrypt user_registry_credential.yml with provided key
           ansible.builtin.shell:
             cmd: |
-              ansible-vault encrypt "{{ input_project_dir }}/user_registry_credential.yml" \
-                --vault-password-file "{{ input_project_dir }}/.local_repo_credentials_key"
+              ansible-vault encrypt "{{ input_project_dir }}/{{ user_registry_file_name }}" \
+                --vault-password-file "{{ input_project_dir }}/{{ user_registry_key_name }}"
           args:
             executable: /bin/bash
           no_log: true
@@ -133,10 +129,7 @@
 
         - name: Display success message for encrypting plaintext file
           ansible.builtin.debug:
-            msg: |
-              user_registry_credential.yml was plaintext in backup.
-              Copied and encrypted using provided key.
-              Target: {{ input_project_dir }}/user_registry_credential.yml
+            msg: "{{ msg_user_registry_plaintext_encrypted_success }}"
 
     - name: "Case 3b: Error - Encrypted file but key missing"
       when: >-
@@ -144,11 +137,7 @@
         backup_user_registry_content.stdout is defined and
         '$ANSIBLE_VAULT;' in backup_user_registry_content.stdout
       ansible.builtin.fail:
-        msg: |
-          ERROR: Inconsistent state detected for user_registry_credential.yml:
-          - File is encrypted but key file (.local_repo_credentials_key) is missing
-          Please check the backup integrity and ensure both files are present
-          in consistent states.
+        msg: "{{ msg_user_registry_encrypted_missing_key }}"
 
     - name: "Case 3c: File plaintext and key missing - copy file only"
       when: >-
@@ -158,16 +147,12 @@
       block:
         - name: Copy user_registry_credential.yml from backup (plaintext, no key)
           ansible.builtin.copy:
-            src: "{{ backup_location }}/user_registry_credential.yml"
-            dest: "{{ input_project_dir }}/user_registry_credential.yml"
-            mode: '0600'
+            src: "{{ backup_location }}/{{ user_registry_file_name }}"
+            dest: "{{ input_project_dir }}/{{ user_registry_file_name }}"
+            mode: "{{ user_registry_file_mode }}"
             force: true
             remote_src: true
 
         - name: Warn about plaintext copy without key
           ansible.builtin.debug:
-            msg: |
-              user_registry_credential.yml copied in plaintext (no key present in backup).
-              Backup: {{ backup_location }}/user_registry_credential.yml
-              Target: {{ input_project_dir }}/user_registry_credential.yml
-              Note: No encryption performed because key is missing.
+            msg: "{{ msg_user_registry_plaintext_no_key }}"

--- a/upgrade/roles/import_input_parameters/tasks/restore_user_registry_credential.yml
+++ b/upgrade/roles/import_input_parameters/tasks/restore_user_registry_credential.yml
@@ -46,10 +46,7 @@
   when: backup_user_registry_credential_stat.stat.exists
 
 - name: Process user_registry_credential.yml when present in backup
-  when: >-
-    backup_local_repo_credentials_key_stat.stat.exists and
-    backup_user_registry_content.stdout is defined and
-    '$ANSIBLE_VAULT;' in backup_user_registry_content.stdout
+  when: backup_user_registry_content.stdout is defined
   block:
 
     - name: "Case 1: Key present and file encrypted - Copy both"
@@ -58,24 +55,12 @@
         backup_user_registry_content.stdout is defined and
         '$ANSIBLE_VAULT;' in backup_user_registry_content.stdout
       block:
-        - name: Decrypt user_registry_credential.yml using the key
-          ansible.builtin.shell:
-            cmd: |
-              ansible-vault decrypt "{{ input_project_dir }}/user_registry_credential.yml.tmp" \
-                --vault-password-file "{{ input_project_dir }}/.local_repo_credentials_key" \
-                --output "{{ input_project_dir }}/user_registry_credential.yml.decrypted"
-          args:
-            executable: /bin/bash
-          no_log: true
-          register: vault_decrypt_result
-          failed_when: vault_decrypt_result.rc != 0
-          changed_when: false
-
         - name: Copy encrypted user_registry_credential.yml from backup
           ansible.builtin.copy:
             src: "{{ backup_location }}/user_registry_credential.yml"
             dest: "{{ input_project_dir }}/user_registry_credential.yml"
             mode: '0600'
+            force: true
             remote_src: true
 
         - name: Copy local_repo_credentials_key from backup
@@ -83,6 +68,7 @@
             src: "{{ backup_location }}/.local_repo_credentials_key"
             dest: "{{ input_project_dir }}/.local_repo_credentials_key"
             mode: '0600'
+            force: true
             remote_src: true
 
         - name: Display success message for encrypted file restoration
@@ -111,25 +97,77 @@
             "were not configured in the source installation."
           ] }}
 
-    - name: "Case 3: Error - Mismatched state"
+    - name: "Case 3a: File not encrypted but key present - copy and encrypt"
       when: >-
-        (not backup_local_repo_credentials_key_stat.stat.exists and
-         backup_user_registry_content.stdout is defined and
-         '$ANSIBLE_VAULT;' in backup_user_registry_content.stdout) or
-        (backup_local_repo_credentials_key_stat.stat.exists and
-         backup_user_registry_content.stdout is defined and
-         '$ANSIBLE_VAULT;' not in backup_user_registry_content.stdout)
+        backup_local_repo_credentials_key_stat.stat.exists and
+        backup_user_registry_content.stdout is defined and
+        '$ANSIBLE_VAULT;' not in backup_user_registry_content.stdout
+      block:
+        - name: Copy local_repo_credentials_key from backup (unencrypted case)
+          ansible.builtin.copy:
+            src: "{{ backup_location }}/.local_repo_credentials_key"
+            dest: "{{ input_project_dir }}/.local_repo_credentials_key"
+            mode: '0600'
+            force: true
+            remote_src: true
+
+        - name: Copy user_registry_credential.yml from backup (unencrypted)
+          ansible.builtin.copy:
+            src: "{{ backup_location }}/user_registry_credential.yml"
+            dest: "{{ input_project_dir }}/user_registry_credential.yml"
+            mode: '0600'
+            force: true
+            remote_src: true
+
+        - name: Encrypt user_registry_credential.yml with provided key
+          ansible.builtin.shell:
+            cmd: |
+              ansible-vault encrypt "{{ input_project_dir }}/user_registry_credential.yml" \
+                --vault-password-file "{{ input_project_dir }}/.local_repo_credentials_key"
+          args:
+            executable: /bin/bash
+          no_log: true
+          register: vault_encrypt_result
+          failed_when: vault_encrypt_result.rc != 0
+          changed_when: false
+
+        - name: Display success message for encrypting plaintext file
+          ansible.builtin.debug:
+            msg: |
+              user_registry_credential.yml was plaintext in backup.
+              Copied and encrypted using provided key.
+              Target: {{ input_project_dir }}/user_registry_credential.yml
+
+    - name: "Case 3b: Error - Encrypted file but key missing"
+      when: >-
+        not backup_local_repo_credentials_key_stat.stat.exists and
+        backup_user_registry_content.stdout is defined and
+        '$ANSIBLE_VAULT;' in backup_user_registry_content.stdout
       ansible.builtin.fail:
         msg: |
           ERROR: Inconsistent state detected for user_registry_credential.yml:
-          {% if not backup_local_repo_credentials_key_stat.stat.exists and
-             backup_user_registry_content.stdout is defined and
-             '$ANSIBLE_VAULT;' in backup_user_registry_content.stdout %}
           - File is encrypted but key file (.local_repo_credentials_key) is missing
-          {% elif backup_local_repo_credentials_key_stat.stat.exists and
-             backup_user_registry_content.stdout is defined and
-             '$ANSIBLE_VAULT;' not in backup_user_registry_content.stdout %}
-          - Key file exists but file is not encrypted
-          {% endif %}
           Please check the backup integrity and ensure both files are present
           in consistent states.
+
+    - name: "Case 3c: File plaintext and key missing - copy file only"
+      when: >-
+        not backup_local_repo_credentials_key_stat.stat.exists and
+        backup_user_registry_content.stdout is defined and
+        '$ANSIBLE_VAULT;' not in backup_user_registry_content.stdout
+      block:
+        - name: Copy user_registry_credential.yml from backup (plaintext, no key)
+          ansible.builtin.copy:
+            src: "{{ backup_location }}/user_registry_credential.yml"
+            dest: "{{ input_project_dir }}/user_registry_credential.yml"
+            mode: '0600'
+            force: true
+            remote_src: true
+
+        - name: Warn about plaintext copy without key
+          ansible.builtin.debug:
+            msg: |
+              user_registry_credential.yml copied in plaintext (no key present in backup).
+              Backup: {{ backup_location }}/user_registry_credential.yml
+              Target: {{ input_project_dir }}/user_registry_credential.yml
+              Note: No encryption performed because key is missing.

--- a/upgrade/roles/import_input_parameters/vars/main.yml
+++ b/upgrade/roles/import_input_parameters/vars/main.yml
@@ -79,6 +79,35 @@ msg_user_registry_decrypt_error: |-
   Please check the backup integrity and ensure the key file
   matches the encrypted file.
 
+# User registry credential restore messages and modes
+user_registry_file_mode: '0600'
+user_registry_key_mode: '0600'
+user_registry_file_name: "user_registry_credential.yml"
+user_registry_key_name: ".local_repo_credentials_key"
+
+msg_user_registry_encrypted_success: |-
+  user_registry_credential.yml restored from backup.
+  Backup: {{ backup_location }}/user_registry_credential.yml
+  Target: {{ input_project_dir }}/user_registry_credential.yml
+  Status: Encrypted (key file also restored)
+
+msg_user_registry_plaintext_encrypted_success: |-
+  user_registry_credential.yml was plaintext in backup.
+  Copied and encrypted using provided key.
+  Target: {{ input_project_dir }}/user_registry_credential.yml
+
+msg_user_registry_plaintext_no_key: |-
+  user_registry_credential.yml copied in plaintext (no key present in backup).
+  Backup: {{ backup_location }}/user_registry_credential.yml
+  Target: {{ input_project_dir }}/user_registry_credential.yml
+  Note: No encryption performed because key is missing.
+
+msg_user_registry_encrypted_missing_key: |-
+  ERROR: Inconsistent state detected for user_registry_credential.yml:
+  - File is encrypted but key file (.local_repo_credentials_key) is missing
+  Please check the backup integrity and ensure both files are present
+  in consistent states.
+
 msg_omnia_config_decrypt_error: |-
   ERROR: Failed to decrypt omnia_config_credentials.yml.
   The backup key file may be corrupted or incompatible.


### PR DESCRIPTION
Removed redundant decryption logic, added tasks to take care of scenarios where file is decrypted with key present and with key missing