### PR TITLE
Restart ldms store pod to enable metrics collection

### DIFF
--- a/discovery/roles/telemetry/tasks/restart_ldms_configs.yml
+++ b/discovery/roles/telemetry/tasks/restart_ldms_configs.yml
@@ -215,7 +215,10 @@
 
     - name: Display LDMS store daemon restart status
       ansible.builtin.debug:
-        msg: "{{ 'LDMS store daemon pod restarted successfully and is ready' if (ldms_store_pod_ready.resources | default([]) | length > 0) else 'LDMS store daemon pod restart failed or not ready within timeout' }}"
+        msg: >
+          {{ ldms_store_pod_ready_msg
+          if (ldms_store_pod_ready.resources | default([]) | length > 0)
+          else ldms_store_pod_not_ready_msg }}
       when:
         - ldms_store_running | default(false) | bool
         - ldms_conf_file.stat.exists | default(false)

--- a/discovery/roles/telemetry/tasks/restart_ldms_configs.yml
+++ b/discovery/roles/telemetry/tasks/restart_ldms_configs.yml
@@ -149,3 +149,74 @@
         - ldms_running | default(false) | bool
         - ldms_conf_file.stat.exists | default(false)
         - ldms_bin_file.stat.exists | default(false)
+
+    - name: Wait 20 seconds before restarting store daemon
+      ansible.builtin.pause:
+        seconds: 10
+      when:
+        - ldms_running | default(false) | bool
+        - ldms_conf_file.stat.exists | default(false)
+        - ldms_bin_file.stat.exists | default(false)
+
+    - name: Check if LDMS store daemon is running on service k8s cluster
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ telemetry_namespace }}"
+        label_selectors:
+          - "app=nersc-ldms-store"
+      delegate_to: "{{ kube_vip }}"
+      register: ldms_store_pod_info
+      failed_when: false
+      when:
+        - kube_vip_reachable | bool
+        - ldms_running | default(false) | bool
+
+    - name: Set LDMS store daemon running state
+      ansible.builtin.set_fact:
+        ldms_store_running: "{{ ldms_store_pod_info.resources is defined and ldms_store_pod_info.resources | length > 0 }}"
+      when:
+        - kube_vip_reachable | bool
+        - ldms_running | default(false) | bool
+
+    - name: Restart LDMS store daemon pod
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        name: "{{ ldms_store_pod_info.resources[0].metadata.name }}"
+        namespace: "{{ telemetry_namespace }}"
+      delegate_to: "{{ kube_vip }}"
+      failed_when: false
+      when:
+        - ldms_store_running | default(false) | bool
+        - ldms_conf_file.stat.exists | default(false)
+        - ldms_bin_file.stat.exists | default(false)
+
+    - name: Wait for LDMS store daemon pod to be ready after restart
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ telemetry_namespace }}"
+        label_selectors:
+          - "app=nersc-ldms-store"
+        wait: true
+        wait_condition:
+          type: Ready
+          status: "True"
+        wait_timeout: 120
+      delegate_to: "{{ kube_vip }}"
+      register: ldms_store_pod_ready
+      failed_when: false
+      when:
+        - ldms_store_running | default(false) | bool
+        - ldms_conf_file.stat.exists | default(false)
+        - ldms_bin_file.stat.exists | default(false)
+
+    - name: Display LDMS store daemon restart status
+      ansible.builtin.debug:
+        msg: "{{ 'LDMS store daemon pod restarted successfully and is ready' if (ldms_store_pod_ready.resources | default([]) | length > 0) else 'LDMS store daemon pod restart failed or not ready within timeout' }}"
+      when:
+        - ldms_store_running | default(false) | bool
+        - ldms_conf_file.stat.exists | default(false)
+        - ldms_bin_file.stat.exists | default(false)

--- a/discovery/roles/telemetry/tasks/restart_ldms_configs.yml
+++ b/discovery/roles/telemetry/tasks/restart_ldms_configs.yml
@@ -150,9 +150,9 @@
         - ldms_conf_file.stat.exists | default(false)
         - ldms_bin_file.stat.exists | default(false)
 
-    - name: Wait 20 seconds before restarting store daemon
+    - name: Wait before restarting store daemon
       ansible.builtin.pause:
-        seconds: 10
+        seconds: "{{ ldms_store_restart_wait_seconds }}"
       when:
         - ldms_running | default(false) | bool
         - ldms_conf_file.stat.exists | default(false)

--- a/discovery/roles/telemetry/vars/main.yml
+++ b/discovery/roles/telemetry/vars/main.yml
@@ -273,3 +273,5 @@ kube_vip_unreachable_msg: >-
 
 ldms_pod_ready_msg: "LDMS aggregator pod is ready."
 ldms_pod_not_ready_msg: "WARNING: LDMS aggregator pod did not become ready within 120s."
+ldms_store_pod_ready_msg: "LDMS store daemon pod restarted successfully and is ready"
+ldms_store_pod_not_ready_msg: "LDMS store daemon pod restart failed or not ready within timeout"

--- a/discovery/roles/telemetry/vars/main.yml
+++ b/discovery/roles/telemetry/vars/main.yml
@@ -275,3 +275,4 @@ ldms_pod_ready_msg: "LDMS aggregator pod is ready."
 ldms_pod_not_ready_msg: "WARNING: LDMS aggregator pod did not become ready within 120s."
 ldms_store_pod_ready_msg: "LDMS store daemon pod restarted successfully and is ready"
 ldms_store_pod_not_ready_msg: "LDMS store daemon pod restart failed or not ready within timeout"
+ldms_store_restart_wait_seconds: 10


### PR DESCRIPTION
### Issues Resolved by this Pull Request
For newly added nodes intermittent issue is observed with metrics collections. Hence restarting the ldms store pod for it to fetch new metric every time a node is added.

Fixes #

### Description of the Solution
Please describe the solution provided and how it resolves the associated issues.

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
