### PR TITLE
fix: Job status updated on stage failures.

### DIFF
--- a/build_stream/container.py
+++ b/build_stream/container.py
@@ -195,6 +195,7 @@ class DevContainer(containers.DeclarativeContainer):  # pylint: disable=R0903
     result_poller = providers.Singleton(
         ResultPoller,
         result_service=playbook_queue_result_service,
+        job_repo=job_repository,
         stage_repo=stage_repository,
         audit_repo=audit_repository,
         uuid_generator=uuid_generator,
@@ -366,6 +367,7 @@ class ProdContainer(containers.DeclarativeContainer):  # pylint: disable=R0903
     result_poller = providers.Singleton(
         ResultPoller,
         result_service=playbook_queue_result_service,
+        job_repo=job_repository,
         stage_repo=stage_repository,
         audit_repo=audit_repository,
         uuid_generator=uuid_generator,

--- a/build_stream/core/jobs/services.py
+++ b/build_stream/core/jobs/services.py
@@ -16,9 +16,15 @@
 
 import hashlib
 import json
+import logging
+from datetime import datetime, timezone
 from typing import Any, Dict
 
-from .value_objects import RequestFingerprint
+from .entities import AuditEvent
+from .repositories import JobRepository, AuditEventRepository, UUIDGenerator
+from .value_objects import JobId, RequestFingerprint
+
+logger = logging.getLogger(__name__)
 
 
 class FingerprintService:
@@ -52,3 +58,169 @@ class FingerprintService:
         normalized = json.dumps(request_body, sort_keys=True, separators=(',', ':'))
         digest = hashlib.sha256(normalized.encode('utf-8')).hexdigest()
         return RequestFingerprint(digest)
+
+
+class JobStateHelper:
+    """Static utility for centralized job state management.
+    
+    Provides methods to update job state when stages fail or complete,
+    leveraging existing repository dependencies without requiring new services.
+    """
+
+    @staticmethod
+    def handle_stage_failure(
+        job_repo: JobRepository,
+        audit_repo: AuditEventRepository,
+        uuid_generator: UUIDGenerator,
+        job_id: JobId,
+        stage_name: str,
+        error_code: str,
+        error_summary: str,
+        correlation_id: str,
+        client_id: str,
+    ) -> None:
+        """Update job state to FAILED when a stage fails.
+        
+        This method:
+        1. Retrieves the job
+        2. Transitions job to FAILED state (if not already terminal)
+        3. Saves the updated job
+        4. Emits JOB_FAILED audit event
+        5. Commits sessions if repositories have active sessions
+        
+        Args:
+            job_repo: Job repository for loading/saving jobs.
+            audit_repo: Audit repository for emitting events.
+            uuid_generator: UUID generator for event IDs.
+            job_id: Job identifier.
+            stage_name: Name of the failed stage.
+            error_code: Error code from stage failure.
+            error_summary: Error summary from stage failure.
+            correlation_id: Request correlation ID.
+            client_id: Client identifier.
+        """
+        try:
+            job = job_repo.find_by_id(job_id)
+            if job is None:
+                logger.warning(
+                    "Job not found when handling stage failure: job_id=%s, stage=%s",
+                    job_id, stage_name
+                )
+                return
+
+            if job.job_state.is_terminal():
+                logger.info(
+                    "Job already in terminal state: job_id=%s, state=%s, stage=%s",
+                    job_id, job.job_state.value, stage_name
+                )
+                return
+
+            job.fail()
+            job_repo.save(job)
+
+            event = AuditEvent(
+                event_id=str(uuid_generator.generate()),
+                job_id=job_id,
+                event_type="JOB_FAILED",
+                correlation_id=correlation_id,
+                client_id=client_id,
+                timestamp=datetime.now(timezone.utc),
+                details={
+                    "failed_stage": stage_name,
+                    "error_code": error_code,
+                    "error_summary": error_summary,
+                },
+            )
+            audit_repo.save(event)
+
+            # Commit sessions if repositories have active sessions
+            if hasattr(job_repo, 'session') and job_repo.session:
+                job_repo.session.commit()
+            if hasattr(audit_repo, 'session') and audit_repo.session:
+                audit_repo.session.commit()
+
+            logger.info(
+                "Job marked as FAILED: job_id=%s, failed_stage=%s, error_code=%s",
+                job_id, stage_name, error_code
+            )
+
+        except Exception as exc:
+            logger.exception(
+                "Failed to update job state on stage failure: job_id=%s, stage=%s, error=%s",
+                job_id, stage_name, exc
+            )
+
+    @staticmethod
+    def handle_job_completion(
+        job_repo: JobRepository,
+        audit_repo: AuditEventRepository,
+        uuid_generator: UUIDGenerator,
+        job_id: JobId,
+        correlation_id: str,
+        client_id: str,
+    ) -> None:
+        """Update job state to COMPLETED when final stage completes.
+        
+        This method:
+        1. Retrieves the job
+        2. Transitions job to COMPLETED state (if not already terminal)
+        3. Saves the updated job
+        4. Emits JOB_COMPLETED audit event
+        5. Commits sessions if repositories have active sessions
+        
+        Args:
+            job_repo: Job repository for loading/saving jobs.
+            audit_repo: Audit repository for emitting events.
+            uuid_generator: UUID generator for event IDs.
+            job_id: Job identifier.
+            correlation_id: Request correlation ID.
+            client_id: Client identifier.
+        """
+        try:
+            job = job_repo.find_by_id(job_id)
+            if job is None:
+                logger.warning(
+                    "Job not found when handling completion: job_id=%s",
+                    job_id
+                )
+                return
+
+            if job.job_state.is_terminal():
+                logger.info(
+                    "Job already in terminal state: job_id=%s, state=%s",
+                    job_id, job.job_state.value
+                )
+                return
+
+            job.complete()
+            job_repo.save(job)
+
+            event = AuditEvent(
+                event_id=str(uuid_generator.generate()),
+                job_id=job_id,
+                event_type="JOB_COMPLETED",
+                correlation_id=correlation_id,
+                client_id=client_id,
+                timestamp=datetime.now(timezone.utc),
+                details={
+                    "completion_reason": "All stages completed successfully",
+                },
+            )
+            audit_repo.save(event)
+
+            # Commit sessions if repositories have active sessions
+            if hasattr(job_repo, 'session') and job_repo.session:
+                job_repo.session.commit()
+            if hasattr(audit_repo, 'session') and audit_repo.session:
+                audit_repo.session.commit()
+
+            logger.info(
+                "Job marked as COMPLETED: job_id=%s",
+                job_id
+            )
+
+        except Exception as exc:
+            logger.exception(
+                "Failed to update job state on completion: job_id=%s, error=%s",
+                job_id, exc
+            )

--- a/build_stream/infra/db/alembic/versions/20260219_004_create_audit_events_table.py
+++ b/build_stream/infra/db/alembic/versions/20260219_004_create_audit_events_table.py
@@ -43,13 +43,6 @@ def upgrade() -> None:
         sa.Column("client_id", sa.String(128), nullable=False),
         sa.Column("timestamp", sa.DateTime(timezone=True), nullable=False),
         sa.Column("details", JSONB, nullable=True),
-        sa.CheckConstraint(
-            "event_type IN ("
-            "'JOB_CREATED', 'JOB_RETRIEVED', 'JOB_DELETED', "
-            "'STAGE_STARTED', 'STAGE_INVOKED', 'STAGE_COMPLETED', 'STAGE_FAILED'"
-            ")",
-            name="ck_audit_event_type",
-        ),
     )
 
     op.create_index("ix_audit_job_id", "audit_events", ["job_id"])

--- a/build_stream/orchestrator/build_image/use_cases/create_build_image.py
+++ b/build_stream/orchestrator/build_image/use_cases/create_build_image.py
@@ -62,6 +62,7 @@ from core.jobs.repositories import (
     StageRepository,
     UUIDGenerator,
 )
+from core.jobs.services import JobStateHelper
 from core.jobs.value_objects import (
     StageName,
     StageType,
@@ -319,12 +320,27 @@ class CreateBuildImageUseCase:
             )
         except InventoryHostMissingError as exc:
             try:
+                error_code = "INVENTORY_HOST_MISSING"
+                error_summary = exc.message
                 stage.start()
                 stage.fail(
-                    error_code="INVENTORY_HOST_MISSING",
-                    error_summary=exc.message,
+                    error_code=error_code,
+                    error_summary=error_summary,
                 )
                 self._stage_repo.save(stage)
+                
+                # Update job state to FAILED when stage fails
+                JobStateHelper.handle_stage_failure(
+                    job_repo=self._job_repo,
+                    audit_repo=self._audit_repo,
+                    uuid_generator=self._uuid_generator,
+                    job_id=command.job_id,
+                    stage_name=str(stage.stage_name),
+                    error_code=error_code,
+                    error_summary=error_summary,
+                    correlation_id=str(command.correlation_id),
+                    client_id=str(command.client_id),
+                )
             except Exception as save_exc:
                 # If save fails, stage was modified elsewhere
                 log_secure_info(
@@ -375,10 +391,25 @@ class CreateBuildImageUseCase:
                 stage.stage_name
             )
             if fresh_stage:
+                error_code = "INVENTORY_FILE_CREATION_FAILED"
+                error_summary = f"Failed to create inventory file: {str(exc)}"
                 fresh_stage.start()
                 fresh_stage.fail(
-                    error_code="INVENTORY_FILE_CREATION_FAILED",
-                    error_summary=f"Failed to create inventory file: {str(exc)}",
+                    error_code=error_code,
+                    error_summary=error_summary,
+                )
+                
+                # Update job state to FAILED when stage fails
+                JobStateHelper.handle_stage_failure(
+                    job_repo=self._job_repo,
+                    audit_repo=self._audit_repo,
+                    uuid_generator=self._uuid_generator,
+                    job_id=command.job_id,
+                    stage_name=str(fresh_stage.stage_name),
+                    error_code=error_code,
+                    error_summary=error_summary,
+                    correlation_id=str(command.correlation_id),
+                    client_id=str(command.client_id),
                 )
                 self._stage_repo.save(fresh_stage)
             log_secure_info(

--- a/build_stream/orchestrator/catalog/use_cases/generate_input_files.py
+++ b/build_stream/orchestrator/catalog/use_cases/generate_input_files.py
@@ -52,6 +52,7 @@ from core.jobs.repositories import (
     StageRepository,
     UUIDGenerator,
 )
+from core.jobs.services import JobStateHelper
 from core.jobs.value_objects import JobId, StageName, StageType, StageState, JobState
 
 from orchestrator.catalog.commands.generate_input_files import GenerateInputFilesCommand
@@ -412,6 +413,19 @@ class GenerateInputFilesUseCase:
                 "error_code": error_code,
                 "error_summary": error_summary,
             },
+        )
+        
+        # Update job state to FAILED when stage fails
+        JobStateHelper.handle_stage_failure(
+            job_repo=self._job_repo,
+            audit_repo=self._audit_repo,
+            uuid_generator=self._uuid_generator,
+            job_id=command.job_id,
+            stage_name="generate-input-files",
+            error_code=error_code,
+            error_summary=error_summary,
+            correlation_id=str(command.correlation_id),
+            client_id=str(command.client_id),
         )
 
     # ------------------------------------------------------------------

--- a/build_stream/orchestrator/catalog/use_cases/parse_catalog.py
+++ b/build_stream/orchestrator/catalog/use_cases/parse_catalog.py
@@ -50,6 +50,7 @@ from core.jobs.repositories import (
     StageRepository,
     UUIDGenerator,
 )
+from core.jobs.services import JobStateHelper
 from core.jobs.value_objects import (
     ClientId,
     StageName,
@@ -381,6 +382,19 @@ class ParseCatalogUseCase:  # pylint: disable=too-few-public-methods
                 "error_code": error_code,
                 "error_summary": error_summary,
             },
+        )
+        
+        # Update job state to FAILED when stage fails
+        JobStateHelper.handle_stage_failure(
+            job_repo=self._job_repo,
+            audit_repo=self._audit_repo,
+            uuid_generator=self._uuid_generator,
+            job_id=command.job_id,
+            stage_name="parse-catalog",
+            error_code=error_code,
+            error_summary=error_summary,
+            correlation_id=str(command.correlation_id),
+            client_id=str(command.client_id),
         )
 
     # ------------------------------------------------------------------

--- a/build_stream/orchestrator/common/result_poller.py
+++ b/build_stream/orchestrator/common/result_poller.py
@@ -29,10 +29,12 @@ from core.jobs.entities import AuditEvent
 from core.jobs.entities.stage import StageState
 from core.jobs.repositories import (
     AuditEventRepository,
+    JobRepository,
     StageRepository,
     UUIDGenerator,
 )
-from core.jobs.value_objects import StageName
+from core.jobs.services import JobStateHelper
+from core.jobs.value_objects import JobId, StageName
 from core.localrepo.entities import PlaybookResult
 from core.localrepo.services import PlaybookQueueResultService
 
@@ -49,6 +51,7 @@ class ResultPoller:
 
     Attributes:
         result_service: Service for polling NFS result queue.
+        job_repo: Job repository for updating job states.
         stage_repo: Stage repository for updating stage states.
         audit_repo: Audit event repository for emitting events.
         uuid_generator: UUID generator for event IDs.
@@ -59,6 +62,7 @@ class ResultPoller:
     def __init__(
         self,
         result_service: PlaybookQueueResultService,
+        job_repo: JobRepository,
         stage_repo: StageRepository,
         audit_repo: AuditEventRepository,
         uuid_generator: UUIDGenerator,
@@ -68,12 +72,14 @@ class ResultPoller:
 
         Args:
             result_service: Service for polling NFS result queue.
+            job_repo: Job repository implementation.
             stage_repo: Stage repository implementation.
             audit_repo: Audit event repository implementation.
             uuid_generator: UUID generator for identifiers.
             poll_interval: Interval in seconds between polls (default: 5).
         """
         self._result_service = result_service
+        self._job_repo = job_repo
         self._stage_repo = stage_repo
         self._audit_repo = audit_repo
         self._uuid_generator = uuid_generator
@@ -157,6 +163,18 @@ class ResultPoller:
                     result.job_id,
                     result.stage_name,
                 )
+                
+                # Check if this is the final stage (validate-image-on-test)
+                # If so, mark the job as completed
+                if result.stage_name == "validate-image-on-test":
+                    JobStateHelper.handle_job_completion(
+                        job_repo=self._job_repo,
+                        audit_repo=self._audit_repo,
+                        uuid_generator=self._uuid_generator,
+                        job_id=JobId(result.job_id),
+                        correlation_id=result.request_id.value if hasattr(result.request_id, 'value') else str(result.request_id),
+                        client_id=str(result.job_id),
+                    )
             else:
                 error_code = result.error_code or "PLAYBOOK_FAILED"
                 error_summary = result.error_summary or "Playbook execution failed"
@@ -166,6 +184,19 @@ class ResultPoller:
                     result.job_id,
                     result.stage_name,
                     error_code,
+                )
+                
+                # Update job state to FAILED when stage fails
+                JobStateHelper.handle_stage_failure(
+                    job_repo=self._job_repo,
+                    audit_repo=self._audit_repo,
+                    uuid_generator=self._uuid_generator,
+                    job_id=JobId(result.job_id),
+                    stage_name=result.stage_name,
+                    error_code=error_code,
+                    error_summary=error_summary,
+                    correlation_id=result.request_id.value if hasattr(result.request_id, 'value') else str(result.request_id),
+                    client_id=str(result.job_id),
                 )
 
             # Update log file path if available

--- a/build_stream/orchestrator/local_repo/use_cases/create_local_repo.py
+++ b/build_stream/orchestrator/local_repo/use_cases/create_local_repo.py
@@ -32,9 +32,11 @@ from core.jobs.repositories import (
     StageRepository,
     UUIDGenerator,
 )
+from core.jobs.services import JobStateHelper
 from core.jobs.value_objects import (
     StageName,
     StageType,
+    StageState,
 )
 from core.localrepo.entities import PlaybookRequest
 from core.localrepo.exceptions import (
@@ -238,12 +240,27 @@ class CreateLocalRepoUseCase:
             )
         except (InputFilesMissingError, InputDirectoryInvalidError) as exc:
             try:
+                error_code = type(exc).__name__.upper()
+                error_summary = exc.message
                 stage.start()
                 stage.fail(
-                    error_code=type(exc).__name__.upper(),
-                    error_summary=exc.message,
+                    error_code=error_code,
+                    error_summary=error_summary,
                 )
                 self._stage_repo.save(stage)
+                
+                # Update job state to FAILED when stage fails
+                JobStateHelper.handle_stage_failure(
+                    job_repo=self._job_repo,
+                    audit_repo=self._audit_repo,
+                    uuid_generator=self._uuid_generator,
+                    job_id=command.job_id,
+                    stage_name=StageType.CREATE_LOCAL_REPOSITORY.value,
+                    error_code=error_code,
+                    error_summary=error_summary,
+                    correlation_id=str(command.correlation_id),
+                    client_id=str(command.client_id),
+                )
             except Exception as save_exc:
                 # If save fails, stage was modified elsewhere
                 log_secure_info(

--- a/build_stream/orchestrator/validate/use_cases/validate_image_on_test.py
+++ b/build_stream/orchestrator/validate/use_cases/validate_image_on_test.py
@@ -31,6 +31,7 @@ from core.jobs.repositories import (
     StageRepository,
     UUIDGenerator,
 )
+from core.jobs.services import JobStateHelper
 from core.jobs.value_objects import (
     StageName,
     StageState,
@@ -246,11 +247,26 @@ class ValidateImageOnTestUseCase:
             )
         except Exception as exc:
             try:
+                error_code = "QUEUE_SUBMISSION_FAILED"
+                error_summary = str(exc)
                 stage.fail(
-                    error_code="QUEUE_SUBMISSION_FAILED",
-                    error_summary=str(exc),
+                    error_code=error_code,
+                    error_summary=error_summary,
                 )
                 self._stage_repo.save(stage)
+                
+                # Update job state to FAILED when stage fails
+                JobStateHelper.handle_stage_failure(
+                    job_repo=self._job_repo,
+                    audit_repo=self._audit_repo,
+                    uuid_generator=self._uuid_generator,
+                    job_id=command.job_id,
+                    stage_name=StageType.VALIDATE_IMAGE_ON_TEST.value,
+                    error_code=error_code,
+                    error_summary=error_summary,
+                    correlation_id=str(command.correlation_id),
+                    client_id=str(command.client_id),
+                )
             except Exception as save_exc:
                 # If save fails, stage was modified elsewhere
                 log_secure_info(


### PR DESCRIPTION
Add JobStateHelper for centralized job state management and integrate with stage lifecycle. Removed Audit event constraint to make it flexible.

Fixes #
Fixes issue where jobs remained in IN_PROGRESS state after stage failures.

### Description of the Solution
Add JobStateHelper utility to centralize job state transitions
Update job to FAILED when any stage fails with JOB_FAILED audit event
Update job to COMPLETED when final stage succeeds with JOB_COMPLETED event
Integrate helper in ResultPoller and all use cases for consistent state management
Remove audit event type constraint for flexibility and easier future extensions

### Suggested Reviewers

