### PR TITLE
Fix for upgrade input migration for local_repo_config.yml, omnia_config.yml and omnia_config_credentials.yml

### DIFF
--- a/upgrade/roles/import_input_parameters/tasks/restore_omnia_config_credentials.yml
+++ b/upgrade/roles/import_input_parameters/tasks/restore_omnia_config_credentials.yml
@@ -40,25 +40,36 @@
   no_log: true
   when: backup_omnia_config_credentials_stat.stat.exists
 
-- name: Process omnia_config_credentials.yml when present in backup
+- name: Fail if file present but key missing
   when: >-
-    backup_omnia_config_credentials_key_stat.stat.exists and
-    backup_omnia_config_credentials_content.stdout is defined and
-    '$ANSIBLE_VAULT;' in backup_omnia_config_credentials_content.stdout
+    backup_omnia_config_credentials_stat.stat.exists and
+    not backup_omnia_config_credentials_key_stat.stat.exists
+  ansible.builtin.fail:
+    msg: "{{ msg_omnia_config_credentials_error }}"
+
+- name: Process omnia_config_credentials.yml when present in backup (key present)
+  when: >-
+    backup_omnia_config_credentials_stat.stat.exists and
+    backup_omnia_config_credentials_key_stat.stat.exists
   block:
-    - name: "Case 1: Key present and file encrypted - Process and update"
+    - name: Copy omnia_config_credentials_key from backup
+      ansible.builtin.copy:
+        src: "{{ backup_location }}/.omnia_config_credentials_key"
+        dest: "{{ input_project_dir }}/.omnia_config_credentials_key"
+        mode: '0600'
+        remote_src: true
+
+    - name: Set flag if backup file is encrypted
+      ansible.builtin.set_fact:
+        omnia_creds_encrypted: "{{ '$ANSIBLE_VAULT;' in (backup_omnia_config_credentials_content.stdout | default('')) }}"
+
+    - name: "Case 1: Encrypted file - decrypt, template, re-encrypt"
+      when: omnia_creds_encrypted | bool
       block:
         - name: Copy encrypted omnia_config_credentials.yml from backup to temp location
           ansible.builtin.copy:
             src: "{{ backup_location }}/omnia_config_credentials.yml"
             dest: "{{ input_project_dir }}/omnia_config_credentials.yml.tmp"
-            mode: '0600'
-            remote_src: true
-
-        - name: Copy omnia_config_credentials_key from backup
-          ansible.builtin.copy:
-            src: "{{ backup_location }}/.omnia_config_credentials_key"
-            dest: "{{ input_project_dir }}/.omnia_config_credentials_key"
             mode: '0600'
             remote_src: true
 
@@ -92,86 +103,104 @@
           ansible.builtin.fail:
             msg: "{{ msg_omnia_config_decrypt_error }}"
 
-    - name: "Case 1.1: Apply template and encrypt"
-      when: >
-        backup_omnia_config_credentials_key_stat.stat.exists and
-        backup_omnia_config_credentials_content.stdout is defined and
-        '$ANSIBLE_VAULT;' in backup_omnia_config_credentials_content.stdout
+    - name: "Case 2: Plaintext file - read, template, encrypt"
+      when: not (omnia_creds_encrypted | bool)
       block:
-        - name: Set template variables from credentials
+        - name: Read plaintext omnia_config_credentials.yml from backup
+          ansible.builtin.slurp:
+            src: "{{ backup_location }}/omnia_config_credentials.yml"
+          register: plaintext_credentials
+          no_log: true
+
+        - name: Parse plaintext credentials
           ansible.builtin.set_fact:
-            provision_password: "{{ credentials_dict.provision_password | default('') }}"
-            bmc_username: "{{ credentials_dict.bmc_username | default('') }}"
-            bmc_password: "{{ credentials_dict.bmc_password | default('') }}"
-            minio_s3_password: "{{ credentials_dict.minio_s3_password | default('') }}"
-            pulp_password: "{{ credentials_dict.pulp_password | default('') }}"
-            docker_username: "{{ credentials_dict.docker_username | default('') }}"
-            docker_password: "{{ credentials_dict.docker_password | default('') }}"
-            slurm_db_password: "{{ credentials_dict.slurm_db_password | default('') }}"
-            openldap_db_username: "{{ credentials_dict.openldap_db_username | default('') }}"
-            openldap_db_password: "{{ credentials_dict.openldap_db_password | default('') }}"
-            mysqldb_user: "{{ credentials_dict.mysqldb_user | default('') }}"
-            mysqldb_password: "{{ credentials_dict.mysqldb_password | default('') }}"
-            mysqldb_root_password: "{{ credentials_dict.mysqldb_root_password | default('') }}"
-            csi_username: "{{ credentials_dict.csi_username | default('') }}"
-            csi_password: "{{ credentials_dict.csi_password | default('') }}"
-            ldms_sampler_password: "{{ credentials_dict.ldms_sampler_password | default('') }}"
+            credentials_dict: >-
+              {{ plaintext_credentials.content | b64decode | from_yaml }}
           no_log: true
 
-        - name: Write updated content using template
-          ansible.builtin.template:
-            src: omnia_config_credentials.yml.j2
-            dest: "{{ input_project_dir }}/omnia_config_credentials.yml.decrypted"
-            mode: '0600'
-          no_log: true
-
-        - name: Encrypt updated file using the same key
-          ansible.builtin.shell:
-            cmd: |
-              ansible-vault encrypt "{{ input_project_dir }}/omnia_config_credentials.yml.decrypted" \
-                --vault-password-file "{{ input_project_dir }}/.omnia_config_credentials_key" \
-                --output "{{ input_project_dir }}/omnia_config_credentials.yml"
-          args:
-            executable: /bin/bash
-          no_log: true
-          register: vault_encrypt_result
-          failed_when: vault_encrypt_result.rc != 0
-          changed_when: false
-
-        - name: Clean up temporary files
-          ansible.builtin.file:
-            path: "{{ item }}"
-            state: absent
-          loop:
-            - "{{ input_project_dir }}/omnia_config_credentials.yml.tmp"
-            - "{{ input_project_dir }}/omnia_config_credentials.yml.decrypted"
-
-        - name: Display success message
-          ansible.builtin.debug:
-            msg: "{{ msg_omnia_config_credentials_success }}"
-
-      rescue:
-        - name: Fail with template/encryption error message
-          ansible.builtin.fail:
-            msg: "{{ msg_omnia_config_template_error }}\n{{ msg_omnia_config_encrypt_error }}"
-
-    - name: "Case 2: Both key and file missing - Add info warning"
-      when: >
-        not backup_omnia_config_credentials_key_stat.stat.exists and
-        (backup_omnia_config_credentials_content.stdout is not defined or
-         '$ANSIBLE_VAULT;' not in backup_omnia_config_credentials_content.stdout) and
-        "'INFO: Both omnia_config_credentials.yml and .omnia_config_credentials_key' not in (upgrade_warnings | join(' '))"
+    - name: Set template variables from credentials
       ansible.builtin.set_fact:
-        upgrade_warnings: >
-          {{ upgrade_warnings + [msg_omnia_config_credentials_info_missing] }}
+        provision_password: "{{ credentials_dict.provision_password | default('') }}"
+        bmc_username: "{{ credentials_dict.bmc_username | default('') }}"
+        bmc_password: "{{ credentials_dict.bmc_password | default('') }}"
+        minio_s3_password: "{{ credentials_dict.minio_s3_password | default('') }}"
+        pulp_password: "{{ credentials_dict.pulp_password | default('') }}"
+        docker_username: "{{ credentials_dict.docker_username | default('') }}"
+        docker_password: "{{ credentials_dict.docker_password | default('') }}"
+        slurm_db_password: "{{ credentials_dict.slurm_db_password | default('') }}"
+        openldap_db_username: "{{ credentials_dict.openldap_db_username | default('') }}"
+        openldap_db_password: "{{ credentials_dict.openldap_db_password | default('') }}"
+        mysqldb_user: "{{ credentials_dict.mysqldb_user | default('') }}"
+        mysqldb_password: "{{ credentials_dict.mysqldb_password | default('') }}"
+        mysqldb_root_password: "{{ credentials_dict.mysqldb_root_password | default('') }}"
+        csi_username: "{{ credentials_dict.csi_username | default('') }}"
+        csi_password: "{{ credentials_dict.csi_password | default('') }}"
+        ldms_sampler_password: "{{ credentials_dict.ldms_sampler_password | default('') }}"
+      no_log: true
 
-    - name: "Case 3: Error - Mismatched state"
-      when: >
-        (not backup_omnia_config_credentials_key_stat.stat.exists and
-         backup_omnia_config_credentials_content.stdout is defined and
-         '$ANSIBLE_VAULT;' in backup_omnia_config_credentials_content.stdout) or
-        (backup_omnia_config_credentials_key_stat.stat.exists and
-         backup_omnia_config_credentials_content.stdout is defined and
-         '$ANSIBLE_VAULT;' not in backup_omnia_config_credentials_content.stdout)
+    - name: Write updated content using template
+      ansible.builtin.template:
+        src: omnia_config_credentials.yml.j2
+        dest: "{{ input_project_dir }}/omnia_config_credentials.yml.decrypted"
+        mode: '0600'
+      no_log: true
+
+    - name: Encrypt updated file using the key
+      ansible.builtin.shell:
+        cmd: |
+          ansible-vault encrypt "{{ input_project_dir }}/omnia_config_credentials.yml.decrypted" \
+            --vault-password-file "{{ input_project_dir }}/.omnia_config_credentials_key" \
+            --output "{{ input_project_dir }}/omnia_config_credentials.yml"
+      args:
+        executable: /bin/bash
+      no_log: true
+      register: vault_encrypt_result
+      failed_when: vault_encrypt_result.rc != 0
+      changed_when: false
+
+    - name: Clean up temporary files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ input_project_dir }}/omnia_config_credentials.yml.tmp"
+        - "{{ input_project_dir }}/omnia_config_credentials.yml.decrypted"
+
+    - name: Mark credentials processed
+      ansible.builtin.set_fact:
+        omnia_creds_processed: true
+
+    - name: Display success message
+      ansible.builtin.debug:
+        msg: "{{ msg_omnia_config_credentials_success }}"
+
+  rescue:
+    - name: Fail with template/encryption error message
       ansible.builtin.fail:
-        msg: "{{ msg_omnia_config_credentials_error }}"
+        msg: "{{ msg_omnia_config_template_error }}\n{{ msg_omnia_config_encrypt_error }}"
+
+- name: "Case 3: Both key and file missing - Add info warning"
+  when: >
+    ((omnia_creds_processed | default(false) | bool) == false) and
+    not backup_omnia_config_credentials_key_stat.stat.exists and
+    (backup_omnia_config_credentials_content.stdout is not defined or
+     '$ANSIBLE_VAULT;' not in backup_omnia_config_credentials_content.stdout) and
+    "'INFO: Both omnia_config_credentials.yml and .omnia_config_credentials_key' not in (upgrade_warnings | join(' '))"
+  ansible.builtin.set_fact:
+    upgrade_warnings: >
+      {{ upgrade_warnings + [msg_omnia_config_credentials_info_missing] }}
+
+- name: "Case 4: Error - Mismatched state"
+  when: >
+    ((omnia_creds_processed | default(false) | bool) == false) and
+    (
+      (not backup_omnia_config_credentials_key_stat.stat.exists and
+       backup_omnia_config_credentials_content.stdout is defined and
+       '$ANSIBLE_VAULT;' in backup_omnia_config_credentials_content.stdout)
+      or
+      (backup_omnia_config_credentials_key_stat.stat.exists and
+       backup_omnia_config_credentials_content.stdout is defined and
+       '$ANSIBLE_VAULT;' not in backup_omnia_config_credentials_content.stdout)
+    )
+  ansible.builtin.fail:
+    msg: "{{ msg_omnia_config_credentials_error }}"

--- a/upgrade/roles/import_input_parameters/tasks/restore_omnia_config_credentials.yml
+++ b/upgrade/roles/import_input_parameters/tasks/restore_omnia_config_credentials.yml
@@ -181,7 +181,7 @@
 
 - name: "Case 3: Both key and file missing - Add info warning"
   when: >
-    ((omnia_creds_processed | default(false) | bool) == false) and
+    (not (omnia_creds_processed | default(false) | bool)) and
     not backup_omnia_config_credentials_key_stat.stat.exists and
     (backup_omnia_config_credentials_content.stdout is not defined or
      '$ANSIBLE_VAULT;' not in backup_omnia_config_credentials_content.stdout) and
@@ -192,7 +192,7 @@
 
 - name: "Case 4: Error - Mismatched state"
   when: >
-    ((omnia_creds_processed | default(false) | bool) == false) and
+    (not (omnia_creds_processed | default(false) | bool)) and
     (
       (not backup_omnia_config_credentials_key_stat.stat.exists and
        backup_omnia_config_credentials_content.stdout is defined and

--- a/upgrade/roles/import_input_parameters/templates/local_repo_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/local_repo_config.j2
@@ -1,9 +1,8 @@
 # Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -40,11 +39,14 @@
 # Fields:
 #   url         : Base URL of the repository
 #   gpgkey      : GPG key URL (leave empty to disable gpgcheck; Omnia will trust this repo and user is responsible for its security)
-#   name        : Name of the repository
+#   name        : Name of the repository (must start with 'x86_64_', e.g., 'x86_64_my_repo')
 #   sslcacert   : Path to SSL CA certificate (if using SSL)
 #   sslclientkey: Path to SSL client key (if using SSL)
 #   sslclientcert: Path to SSL client certificate (if using SSL)
-#   policy      : Repository policy (always, partial)
+#   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
 # Notes:
 #   - Do not use Jinja variables in this configuration.
 #   - Omit SSL fields entirely if SSL is not in use.
@@ -53,6 +55,7 @@
 # 3. user_repo_url_aarch64
 #---------------------------
 #    Same as above but for aarch64 architecture.
+#    Note: name must start with 'aarch64_' (e.g., 'aarch64_my_repo').
 #
 # 4. rhel_os_url_x86_64
 #-----------------------------
@@ -64,7 +67,10 @@
 #   sslcacert   : Path to SSL CA certificate (if using SSL)
 #   sslclientkey: Path to SSL client key (if using SSL)
 #   sslclientcert: Path to SSL client certificate (if using SSL)
-#   policy      : Repository policy if mentioned allowed values (always, partial). IF not mentioned will consider from software_config.json
+#   policy      : Repository policy if mentioned allowed values (always, partial). 
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
 #   name        : Name of the repository [ Allowed repo names <arch>_codeready-builder, <arch>_appstream, <arch>_baseos
 # Notes:
 #   - Do not use Jinja variables in this configuration.
@@ -76,8 +82,35 @@
 #----------------------------
 #    Same as above but for aarch64 architecture.
 #
+# 6. rhel_subscription_repo_config_x86_64
+#-------------------------------------------
+#    Optional configuration for overriding policy and caching settings for RHEL 
+#    subscription-based repositories on x86_64 architecture.
+#    When subscription is enabled, this config takes precedence over dynamically 
+#    generated URLs for matching repositories and adds any additional repositories.
+# Fields:
+#   url         : Base URL of the repository (REQUIRED)
+#   gpgkey      : GPG key URL (REQUIRED, can be empty to disable gpgcheck)
+#   name        : Repository name for matching (REQUIRED)
+#   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
+#   sslcacert   : Path to SSL CA certificate (optional)
+#   sslclientkey: Path to SSL client key (optional)
+#   sslclientcert: Path to SSL client certificate (optional)
+# Notes:
+#   - Do not use Jinja variables in this configuration.
+#   - Omit SSL fields entirely if SSL is not in use.
+#   - Matching is done by repository name (e.g., x86_64_appstream)
+#   - Non-matching repositories are added as additional repos
+#
+# 7. rhel_subscription_repo_config_aarch64
+#--------------------------------------------
+#    Same as above but for aarch64 architecture.
+#
 #### ADVANCE CONFIGURATIONS FOR LOCAL REPO ###
-# 6. omnia_repo_url_rhel_x86_64
+# 8. omnia_repo_url_rhel_x86_64
 #-------------------------------
 #    Mandatory repository URLs for downloading RPMS for Omnia features on RHEL x86_64.
 #    Each entry includes url, gpgkey, and name.
@@ -89,12 +122,15 @@
 #  gpgkey     : URL of the GPG key for the repository.
 #                   If left empty, gpgcheck=0 for that repository.
 #  name       : A unique identifier for the repository or registry.
-#
-# 7. omnia_repo_url_rhel_aarch64
+#  policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#  caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
+# 9. omnia_repo_url_rhel_aarch64
 #--------------------------------
 #    Same as above but for RHEL aarch64.
 #
-# 8. additional_repos_x86_64
+# 10. additional_repos_x86_64
 #----------------------------
 #    Optional list of additional repository URLs for x86_64 architecture.
 #    These repos are aggregated into a single Pulp repository, allowing dynamic
@@ -106,6 +142,10 @@
 #   sslcacert     : Path to SSL CA certificate (optional)
 #   sslclientkey  : Path to SSL client key (optional)
 #   sslclientcert : Path to SSL client certificate (optional)
+#   policy      : Repository sync policy. Allowed values: always, partial (OPTIONAL)
+#                   If not provided, uses repo_config from software_config.json
+#   caching     : Enable or disable local caching. Allowed values: true, false (OPTIONAL)
+#                   If not provided, defaults to true
 # Notes:
 #   - All repos are synced into a single aggregated Pulp repository
 #   - Compute nodes are configured once with a fixed URL that never changes
@@ -113,7 +153,7 @@
 #   - Name must be unique within this list and must not conflict with names in other repo keys
 #   - Packages from these repos can only be used via additional_packages.json
 #
-# 9. additional_repos_aarch64
+# 11. additional_repos_aarch64
 #-----------------------------
 #    Same as above but for aarch64 architecture.
 
@@ -154,31 +194,33 @@ rhel_os_url_x86_64:
 {% set _rhel_os_url_x86_64 = local_repo_rhel_os_url_x86_64 | default([]) %}
 {% if (_rhel_os_url_x86_64 | length) > 0 %}
 {% for _repo in _rhel_os_url_x86_64 %}
-  - { url: {{ (_repo.url | default('')) | to_json }}, gpgkey: {{ (_repo.gpgkey | default('')) | to_json }}, sslcacert: {{ (_repo.sslcacert | default('')) | to_json }}, sslclientkey: {{ (_repo.sslclientkey | default('')) | to_json }}, sslclientcert: {{ (_repo.sslclientcert | default('')) | to_json }}, name: {{ (_repo.name | default('')) | to_json }}, policy: {{ (_repo.policy | default('')) | to_json }} }
+  - { url: {{ (_repo.url | default('')) | to_json }}, gpgkey: {{ (_repo.gpgkey | default('')) | to_json }}, sslcacert: {{ (_repo.sslcacert | default('')) | to_json }}, sslclientkey: {{ (_repo.sslclientkey | default('')) | to_json }}, sslclientcert: {{ (_repo.sslclientcert | default('')) | to_json }}, name: {{ (_repo.name | default('')) | to_json }} }
 {% endfor %}
 {% endif %}
 rhel_os_url_aarch64:
 {% set _rhel_os_url_aarch64 = local_repo_rhel_os_url_aarch64 | default([]) %}
 {% if (_rhel_os_url_aarch64 | length) > 0 %}
 {% for _repo in _rhel_os_url_aarch64 %}
-  - { url: {{ (_repo.url | default('')) | to_json }}, gpgkey: {{ (_repo.gpgkey | default('')) | to_json }}, sslcacert: {{ (_repo.sslcacert | default('')) | to_json }}, sslclientkey: {{ (_repo.sslclientkey | default('')) | to_json }}, sslclientcert: {{ (_repo.sslclientcert | default('')) | to_json }}, name: {{ (_repo.name | default('')) | to_json }}, policy: {{ (_repo.policy | default('')) | to_json }} }
+  - { url: {{ (_repo.url | default('')) | to_json }}, gpgkey: {{ (_repo.gpgkey | default('')) | to_json }}, sslcacert: {{ (_repo.sslcacert | default('')) | to_json }}, sslclientkey: {{ (_repo.sslclientkey | default('')) | to_json }}, sslclientcert: {{ (_repo.sslclientcert | default('')) | to_json }}, name: {{ (_repo.name | default('')) | to_json }} }
 {% endfor %}
 {% endif %}
+# Example:
+# rhel_subscription_repo_config_x86_64:
+#  - { url: "https://example.com/appstream", gpgkey: "", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "x86_64_appstream", policy: "always", caching: true }
+#  - { url: "https://cdn.redhat.com/content/dist/rhel10/10.0/x86_64/supplementary/os/", gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release", sslcacert: "", sslclientkey: "", sslclientcert: "", name: "x86_64_supplementary", policy: "always", caching: false }
+rhel_subscription_repo_config_x86_64:
+rhel_subscription_repo_config_aarch64:
 # Making incorrect changes to this variable can cause omnia failure. Please edit cautiously.
 omnia_repo_url_rhel_x86_64:
-{% set _omnia_repo_url_rhel_x86_64 = local_repo_omnia_repo_url_rhel_x86_64 | default([]) %}
-{% if (_omnia_repo_url_rhel_x86_64 | length) > 0 %}
-{% for _repo in _omnia_repo_url_rhel_x86_64 %}
-  - { url: {{ (_repo.url | default('')) | to_json }}, gpgkey: {{ (_repo.gpgkey | default('')) | to_json }}, name: {{ (_repo.name | default('')) | to_json }} }
-{% endfor %}
-{% endif %}
+  - { url: "https://download.docker.com/linux/centos/10/x86_64/stable/", gpgkey: "https://download.docker.com/linux/centos/gpg", name: "docker-ce"}
+  - { url: "https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/", gpgkey: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10", name: "epel"}
+  - { url: "https://pkgs.k8s.io/core:/stable:/v1.34/rpm/", gpgkey: "https://pkgs.k8s.io/core:/stable:/v1.34/rpm/repodata/repomd.xml.key", name: "kubernetes"}
+  - { url: "https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v1.34/rpm/", gpgkey: "https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v1.34/rpm/repodata/repomd.xml.key", name: "cri-o"}
+  - { url: "https://linux.mellanox.com/public/repo/doca/3.2.1/rhel10/x86_64/", gpgkey: "https://linux.mellanox.com/public/repo/doca/3.2.1/rhel10/x86_64/repodata/repomd.xml.key", name: "doca"}
 omnia_repo_url_rhel_aarch64:
-{% set _omnia_repo_url_rhel_aarch64 = local_repo_omnia_repo_url_rhel_aarch64 | default([]) %}
-{% if (_omnia_repo_url_rhel_aarch64 | length) > 0 %}
-{% for _repo in _omnia_repo_url_rhel_aarch64 %}
-  - { url: {{ (_repo.url | default('')) | to_json }}, gpgkey: {{ (_repo.gpgkey | default('')) | to_json }}, name: {{ (_repo.name | default('')) | to_json }} }
-{% endfor %}
-{% endif %}
+  - { url: "https://download.docker.com/linux/centos/10/aarch64/stable/", gpgkey: "https://download.docker.com/linux/centos/gpg", name: "docker-ce"}
+  - { url: "https://dl.fedoraproject.org/pub/epel/10/Everything/aarch64/", gpgkey: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10", name: "epel"}
+  - { url: "https://linux.mellanox.com/public/repo/doca/3.2.1/rhel10/arm64-sbsa/", gpgkey: "https://linux.mellanox.com/public/repo/doca/3.2.1/rhel10/arm64-sbsa/repodata/repomd.xml.key", name: "doca"}
 # Example:
 # additional_repos_x86_64:
 #  - { url: "https://rpm.grafana.com/", gpgkey: "", name: "grafana" }

--- a/upgrade/roles/import_input_parameters/templates/omnia_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/omnia_config.j2
@@ -27,17 +27,84 @@
 # Storage name corresponding to the NFS share to be used by slurm cluster 
 # This should match with exactly with a entry in storage_config.yml
 
+# skip_merge
+# Variable indicates whether a specific configuration file path
+# under config_sources should be used as-is without merging
+# If skip_merge is set to true for a configuration source path,
+# that configuration file will be applied directly
+# without merging with defaults or existing configurations
+# It accepts true and false values
+# Default value is false
+
+# node_discovery_mode
+# Controls how hardware specifications are discovered for Slurm compute nodes
+# Options: "heterogeneous" or "homogeneous"
+# - heterogeneous: Discovers each node individually via iDRAC (1 call per node)
+#   Best for: Mixed hardware environments with different node configurations
+# - homogeneous: Groups nodes by hardware type for optimized discovery
+#   Best for: Standardized hardware groups (grp0-grp100 in pxe_mapping_file.csv)
+#   Performance: 0 iDRAC calls (with specs) or 1 call per group (without specs)
+# Default value is heterogeneous
+
+# node_hardware_defaults
+# Optional: Pre-define hardware specifications for homogeneous node groups
+# Only used when node_discovery_mode is set to "homogeneous"
+# Key: GROUP_NAME from pxe_mapping_file.csv (e.g., grp0, grp1, grp2, etc.)
+# Value: Hardware specifications for all nodes in that group
+#   - sockets: Number of CPU sockets per node (integer, minimum 1)
+#   - cores_per_socket: Number of CPU cores per socket (integer, minimum 1)
+#   - threads_per_core: Number of CPU threads per core (integer, minimum 1)
+#   - real_memory: Memory in MB (integer, minimum 1)
+#   - gres: Optional GPU resources in format "gpu:N" (e.g., "gpu:4")
+# If a group is not listed here, one node from that group will be discovered via iDRAC
+# and the specs will be applied to all nodes in the group
+# Example:
+#   node_hardware_defaults:
+#     grp1:
+#       sockets: 2
+#       cores_per_socket: 64
+#       threads_per_core: 2
+#       real_memory: 512000
+#       gres: "gpu:4"
+#     grp2:
+#       sockets: 2
+#       cores_per_socket: 32
+#       threads_per_core: 2
+#       real_memory: 256000
+
 # config_sources
 # defines how the Slurm configuration files are provided to the cluster.
 # <conf name>: 
 #    <mapping> or <filepath>
 # <mapping> Supply the configuration values directly as a key–value map
 # <filepath> Supply the absolute path to a custom configuration file
+#            This path can be any path inside the omnia_core container.
+#            The default input path "/opt/omnia/input/project_default" 
+#            can also be used to place the custom conf files
+# Example (slurm mapping):
+#   config_sources:
+#     slurm:
+#       SlurmctldTimeout: 60
+#       SlurmdTimeout: 150
+#       NodeName:
+#         - NodeName: node1
+#           CPUs: 16
+#           RealMemory: 64000
+#         - NodeName: node2
+#           CPUs: 16
+#           RealMemory: 64000
 # The conf files supported by slurm are
 # slurm
 # cgroup
 # slurmdbd
 # gres
+# acct_gather
+# helpers
+# job_container
+# mpi
+# oci
+# topology
+# burst_buffer
 # Thes files will be written into the slurm_config directory with .conf suffix
 
 slurm_cluster:
@@ -46,13 +113,39 @@ slurm_cluster:
 {% for _cluster in _slurm_cluster %}
   - cluster_name: {{ _cluster.cluster_name | default('') }}
     nfs_storage_name: {{ _cluster.nfs_storage_name | default('') }}
+    # skip_merge: True
+
+    # Uncomment to enable homogeneous discovery mode
+    # node_discovery_mode: "homogeneous"
+
+    # # Optional hardware specs per group (if omitted, one node per group is discovered via iDRAC)
+    # node_hardware_defaults:
+    #   grp1:
+    #     sockets: 2
+    #     cores_per_socket: 64
+    #     threads_per_core: 2
+    #     real_memory: 512000
+    #     gres: "gpu:4"
+    #   grp2:
+    #     sockets: 2
+    #     cores_per_socket: 32
+    #     threads_per_core: 2
+    #     real_memory: 256000
+
 {% if _cluster.config_sources is defined and (_cluster.config_sources | length > 0) %}
-    skip_merge: {{ _cluster.skip_merge | default(true) }}
+
     config_sources:
 {% set _supported = ['slurm', 'cgroup', 'slurmdbd', 'gres'] %}
 {% for _conf_name, _conf_val in _cluster.config_sources.items() %}
 {% if _conf_name in _supported %}
 {% if _conf_name == 'cgroup' and (_conf_val is mapping) %}
+    #    NodeName:
+    #      - NodeName: newnode1
+    #        CPUs: 16
+    #        RealMemory: 64000
+    #      - NodeName: newnode2
+    #        CPUs: 16
+    #        RealMemory: 64000
       cgroup:
         CgroupPlugin: {{ _conf_val.CgroupPlugin | default('autodetect') }}
 {% for _k, _v in _conf_val.items() %}
@@ -85,11 +178,18 @@ slurm_cluster:
     #   slurmdbd: /path/to/custom_slurmdbd.conf
     #   gres: /path/to/custom_gres.conf
 {% else %}
-    # skip_merge: True
+
     # config_sources:
     #   slurm:
     #     SlurmctldTimeout: 60
     #     SlurmdTimeout: 150
+    #     NodeName:
+    #       - NodeName: newnode1
+    #         CPUs: 16
+    #         RealMemory: 64000
+    #       - NodeName: newnode2
+    #         CPUs: 16
+    #         RealMemory: 64000
     #   cgroup:
     #     CgroupPlugin: autodetect
     #     ConstrainCores: True
@@ -108,21 +208,6 @@ slurm_cluster:
 {% endfor %}
 {% endif %}
 
-    # node_discovery_mode: "homogeneous"
-    # # Specify hardware specs for groups (optional - will use group iDRAC if not specified)
-    # node_hardware_defaults:
-    #   grp12:
-    #     sockets: 5
-    #     cores_per_socket: 6
-    #     threads_per_core: 3
-    #     real_memory: 117968
-    #     gres: "gpu:4"  # optional
-
-    #   grp13:
-    #     sockets: 13
-    #     cores_per_socket: 13
-    #     threads_per_core: 13
-    #     real_memory: 117913
 
 # ----------------------------SERVICE K8S------------------------------------------------------
 # For service k8s cluster below parameters are required,(List)

--- a/upgrade/roles/import_input_parameters/templates/omnia_config.j2
+++ b/upgrade/roles/import_input_parameters/templates/omnia_config.j2
@@ -113,7 +113,7 @@ slurm_cluster:
 {% for _cluster in _slurm_cluster %}
   - cluster_name: {{ _cluster.cluster_name | default('') }}
     nfs_storage_name: {{ _cluster.nfs_storage_name | default('') }}
-    # skip_merge: True
+    # skip_merge: False
 
     # Uncomment to enable homogeneous discovery mode
     # node_discovery_mode: "homogeneous"
@@ -135,39 +135,14 @@ slurm_cluster:
 {% if _cluster.config_sources is defined and (_cluster.config_sources | length > 0) %}
 
     config_sources:
-{% set _supported = ['slurm', 'cgroup', 'slurmdbd', 'gres'] %}
 {% for _conf_name, _conf_val in _cluster.config_sources.items() %}
-{% if _conf_name in _supported %}
-{% if _conf_name == 'cgroup' and (_conf_val is mapping) %}
-    #    NodeName:
-    #      - NodeName: newnode1
-    #        CPUs: 16
-    #        RealMemory: 64000
-    #      - NodeName: newnode2
-    #        CPUs: 16
-    #        RealMemory: 64000
-      cgroup:
-        CgroupPlugin: {{ _conf_val.CgroupPlugin | default('autodetect') }}
-{% for _k, _v in _conf_val.items() %}
-{% if _k not in ['AllowedRAMSpace', 'CgroupPlugin', 'ConstrainCores', 'ConstrainDevices', 'ConstrainRAMSpace', 'ConstrainSwapSpace'] %}
-        {{ _k }}: {{ _v }}
-{% endif %}
-{% endfor %}
-        ConstrainCores: {{ _conf_val.ConstrainCores | default(true) }}
-        ConstrainDevices: {{ _conf_val.ConstrainDevices | default(true) }}
-        ConstrainRAMSpace: {{ _conf_val.ConstrainRAMSpace | default(true) }}
-        ConstrainSwapSpace: {{ _conf_val.ConstrainSwapSpace | default(true) }}
-{% if _conf_val.AllowedRAMSpace is defined %}
-        ### AllowedRAMSpace: {{ _conf_val.AllowedRAMSpace }}       This is not supported in 2.1, just attached for reference
-{% endif %}
-{% elif _conf_val is mapping %}
+{% if _conf_val is mapping %}
       {{ _conf_name }}:
 {% for _k, _v in _conf_val.items() %}
         {{ _k }}: {{ _v }}
 {% endfor %}
 {% else %}
       {{ _conf_name }}: {{ _conf_val }}
-{% endif %}
 {% endif %}
 {% endfor %}
     #   OR

--- a/upgrade/roles/upgrade_cluster/tasks/main.yml
+++ b/upgrade/roles/upgrade_cluster/tasks/main.yml
@@ -35,6 +35,10 @@
 
         1. local_repo_config.yml
 
+            - Set rhel_subscription_repo_config_x86_64 (list of RHEL subscription repos for x86_64)
+
+            - Set rhel_subscription_repo_config_aarch64 (list of RHEL subscription repos for aarch64)
+
             - Set additional_repos_x86_64 (list of extra repo URLs or file paths for x86_64)
 
             - Set additional_repos_aarch64 (list of extra repo URLs or file paths for aarch64)
@@ -70,6 +74,23 @@
               Homogeneous without specs | One node per group queried, specs shared 1 per group
 
               also provide node_hardware_defaults for groups where you want to apply specs
+
+
+            - New sample fields under slurm_cluster for Slurm cgroup and NodeName definitions:
+
+              NodeName entries (list of nodes with CPUs/RealMemory)
+
+              cgroup settings (CgroupPlugin and constrain flags)
+
+              These fields are added and populated with default values when using config_source; adjust them manually as needed for your cluster.
+
+
+        4. software_config.json
+
+            - Migrated as-is from backup during upgrade
+
+            - Review and manually update as needed before proceeding.
+
 
       Optional: NFS cleanup (only if you are reprovisioning the cluster)
 

--- a/upgrade/roles/upgrade_cluster/tasks/main.yml
+++ b/upgrade/roles/upgrade_cluster/tasks/main.yml
@@ -57,7 +57,8 @@
 
             - Populate location to point to your Slurm config bundle (local path or remote URL)
 
-            - New variable: skip_merge (set to true to skip merging configs during upgrade when using external bundles)
+            - New variable: skip_merge (boolean, default: false,  If skip_merge is set to true for a configuration source path,
+              that configuration file will be applied directly without merging with defaults or existing configurations)
 
             - New variable: node_discovery_mode: 'Homogeneous' or 'Heterogeneous'
 
@@ -79,10 +80,6 @@
             - New sample fields under slurm_cluster for Slurm cgroup and NodeName definitions:
 
               NodeName entries (list of nodes with CPUs/RealMemory)
-
-              cgroup settings (CgroupPlugin and constrain flags)
-
-              These fields are added and populated with default values when using config_source; adjust them manually as needed for your cluster.
 
 
         4. software_config.json


### PR DESCRIPTION
Fixed invalid policy error caused by local_repo_config.yml being generated with invalid policy field. Modified local_repo_config.j2 to take care of the new fields. Modified omnia_config.j2 to provide the latest input file format after upgrade migration. Added info about these new fields as part of reprovision guidance that appears after upgrade_omnia.yml runs successfully. Also modified logic for omnia_config_credentials.yml migration to take care of all the cases.