### PR TITLE
Restrict the concurrent jobs to 1 in watcher service

### DIFF
--- a/build_stream/playbook-watcher/playbook_watcher_service.py
+++ b/build_stream/playbook-watcher/playbook_watcher_service.py
@@ -79,7 +79,7 @@ HOST_LOG_BASE_DIR = NFS_SHARE_PATH / "omnia" / "log" / "build_stream"
 CONTAINER_LOG_BASE_DIR = Path("/opt/omnia/log/build_stream")
 
 POLL_INTERVAL_SECONDS = int(os.getenv("POLL_INTERVAL_SECONDS", "2"))
-MAX_CONCURRENT_JOBS = int(os.getenv("MAX_CONCURRENT_JOBS", "5"))
+MAX_CONCURRENT_JOBS = int(os.getenv("MAX_CONCURRENT_JOBS", "1"))
 DEFAULT_TIMEOUT_MINUTES = int(os.getenv("DEFAULT_TIMEOUT_MINUTES", "30"))
 
 # Playbook name to full path mapping - prevents injection from user input

--- a/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
+++ b/prepare_oim/roles/deploy_containers/build_stream/vars/main.yml
@@ -53,7 +53,7 @@ watcher_memory_max: "512M"
 watcher_cpu_quota: "50%"
 build_stream_watcher_playbook_queue_base: "{{ omnia_path }}/omnia/playbook_queue"
 watcher_poll_interval_seconds: 2
-watcher_max_concurrent_jobs: 5
+watcher_max_concurrent_jobs: 1
 watcher_default_timeout_minutes: 150
 watcher_log_level: "INFO"
 


### PR DESCRIPTION


### Description of the Solution
Restrict the concurrent jobs to 1 in watcher service

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@priti-parate @Venu-p1 @abhishek-sa1 