### PR TITLE
fix: handle API layer validation failures by marking stages as FAILED

### DIFF
--- a/build_stream/api/dependencies.py
+++ b/build_stream/api/dependencies.py
@@ -200,7 +200,7 @@ def get_db_session() -> Generator[Session, None, None]:
     if _ENV != "prod":
         yield None  # type: ignore[misc]
         return
-    
+
     from infra.db.session import SessionLocal  # pylint: disable=import-outside-toplevel
     session = SessionLocal()
     try:
@@ -238,6 +238,62 @@ def _create_sql_audit_repo(session: Session):
     """Create SQL audit event repository with session."""
     from infra.db.repositories import SqlAuditEventRepository  # pylint: disable=import-outside-toplevel
     return SqlAuditEventRepository(session=session)
+
+
+# ------------------------------------------------------------------
+# Stage Failure Helper
+# ------------------------------------------------------------------
+def mark_stage_as_failed(
+    job_id: str, stage_name: str, error_code: str, error_summary: str, db_session: Session = None
+):
+    """Mark a stage as failed when validation fails at API layer.
+    
+    Args:
+        job_id: The job identifier
+        stage_name: The stage name (e.g., 'parse-catalog')
+        error_code: Error classification code
+        error_summary: Human-readable error description
+        db_session: Database session (if None, creates new session)
+    """
+    from core.jobs.value_objects import JobId, StageName  # pylint: disable=import-outside-toplevel
+
+    try:
+        # Get or create session
+        if db_session is None and _ENV == "prod":
+            from infra.db.session import SessionLocal  # pylint: disable=import-outside-toplevel
+            db_session = SessionLocal()
+            should_close = True
+        else:
+            should_close = False
+
+        stage_repo = (
+            _create_sql_stage_repo(db_session)
+            if _ENV == "prod"
+            else _get_container().stage_repository()
+        )
+
+        # Find the stage
+        stage = stage_repo.find_by_job_and_name(JobId(job_id), StageName(stage_name))
+
+        if stage and stage.stage_state.value == "PENDING":
+            # Start the stage first if it's still PENDING
+            stage.start()
+            stage_repo.save(stage)
+
+            # Then mark it as failed
+            stage.fail(error_code=error_code, error_summary=error_summary)
+            stage_repo.save(stage)
+
+            if _ENV == "prod":
+                db_session.commit()
+
+        if should_close and db_session:
+            db_session.close()
+
+    except Exception as e:
+        logger.warning("Failed to mark stage as failed: %s", e)
+        if db_session:
+            db_session.rollback()
 
 
 # ------------------------------------------------------------------

--- a/build_stream/api/dependencies.py
+++ b/build_stream/api/dependencies.py
@@ -291,7 +291,7 @@ def mark_stage_as_failed(
             db_session.close()
 
     except Exception as e:
-        logger.warning("Failed to mark stage as failed: %s", e)
+        log_secure_info("warning", "Failed to mark stage as failed: %s", str(e))
         if db_session:
             db_session.rollback()
 

--- a/build_stream/api/dependencies.py
+++ b/build_stream/api/dependencies.py
@@ -248,6 +248,8 @@ def mark_stage_as_failed(
 ):
     """Mark a stage as failed when validation fails at API layer.
     
+    Also marks the job as FAILED to maintain consistency with orchestrator behavior.
+    
     Args:
         job_id: The job identifier
         stage_name: The stage name (e.g., 'parse-catalog')
@@ -256,6 +258,7 @@ def mark_stage_as_failed(
         db_session: Database session (if None, creates new session)
     """
     from core.jobs.value_objects import JobId, StageName  # pylint: disable=import-outside-toplevel
+    from core.jobs.services import JobStateHelper  # pylint: disable=import-outside-toplevel
 
     try:
         # Get or create session
@@ -284,14 +287,47 @@ def mark_stage_as_failed(
             stage.fail(error_code=error_code, error_summary=error_summary)
             stage_repo.save(stage)
 
-            if _ENV == "prod":
+            # Commit after failing the stage
+            if _ENV == "prod" and db_session.is_active:
                 db_session.commit()
+
+            # Also mark the job as FAILED (same as orchestrator)
+            if _ENV == "prod":
+                from infra.id_generator import UUIDv4Generator  # pylint: disable=import-outside-toplevel
+                
+                job_repo = _create_sql_job_repo(db_session)
+                audit_repo = _create_sql_audit_repo(db_session)
+                uuid_generator = UUIDv4Generator()
+                
+                # Transition job to IN_PROGRESS first if it's CREATED
+                job = job_repo.find_by_id(JobId(job_id))
+                if job and job.job_state.value == "CREATED":
+                    job.start()
+                    job_repo.save(job)
+                    if db_session.is_active:
+                        db_session.commit()
+                
+                JobStateHelper.handle_stage_failure(
+                    job_repo=job_repo,
+                    audit_repo=audit_repo,
+                    uuid_generator=uuid_generator,
+                    job_id=JobId(job_id),
+                    stage_name=stage_name,
+                    error_code=error_code,
+                    error_summary=error_summary,
+                    correlation_id=str(uuid_generator.generate()),
+                    client_id="unknown",
+                )
+                
+                # Ensure the session is committed after JobStateHelper completes
+                if db_session.is_active:
+                    db_session.commit()
 
         if should_close and db_session:
             db_session.close()
 
     except Exception as e:
-        log_secure_info("warning", "Failed to mark stage as failed: %s", str(e))
+        log_secure_info("warning", "Failed to mark stage as failed: %s", str(e), job_id=job_id)
         if db_session:
             db_session.rollback()
 

--- a/build_stream/api/generate_input_files/routes.py
+++ b/build_stream/api/generate_input_files/routes.py
@@ -19,7 +19,7 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 
-from api.dependencies import require_catalog_read, verify_token
+from api.dependencies import require_catalog_read, verify_token, mark_stage_as_failed, get_db_session
 from api.generate_input_files.dependencies import get_generate_input_files_use_case
 from api.logging_utils import log_secure_info
 from core.artifacts.exceptions import ArtifactNotFoundError
@@ -69,6 +69,7 @@ async def generate_input_files(
     token_data: Annotated[dict, Depends(verify_token)] = None,  # pylint: disable=unused-argument
     scope_data: Annotated[dict, Depends(require_catalog_read)] = None,  # pylint: disable=unused-argument
     use_case: Annotated[GenerateInputFilesUseCase, Depends(get_generate_input_files_use_case)] = None,
+    db_session = Depends(get_db_session),
 ) -> GenerateInputFilesResponse:
     """Generate Omnia input files from a parsed catalog.
 
@@ -110,6 +111,8 @@ async def generate_input_files(
             )
         except ValueError as e:
             log_secure_info("error", f"Generate-input-files failed: job_id={job_id}, reason=invalid_policy_path, status=400", job_id=job_id, end_section=True)
+            # Mark stage as failed since validation failed at API layer
+            mark_stage_as_failed(job_id, "generate-input-files", "INVALID_POLICY_PATH", str(e), db_session)
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail={"error": "INVALID_POLICY_PATH", "message": str(e)},

--- a/build_stream/api/parse_catalog/routes.py
+++ b/build_stream/api/parse_catalog/routes.py
@@ -18,7 +18,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 
-from api.dependencies import require_catalog_read, verify_token
+from api.dependencies import require_catalog_read, verify_token, mark_stage_as_failed, get_db_session
 from api.parse_catalog.dependencies import get_parse_catalog_use_case
 from api.parse_catalog.schemas import ErrorResponse, ParseCatalogResponse, ParseCatalogStatus
 from api.parse_catalog.service import (
@@ -79,6 +79,7 @@ async def parse_catalog(
     token_data: Annotated[dict, Depends(verify_token)] = None,  # pylint: disable=unused-argument
     scope_data: Annotated[dict, Depends(require_catalog_read)] = None,  # pylint: disable=unused-argument
     parse_catalog_use_case = Depends(get_parse_catalog_use_case),
+    db_session = Depends(get_db_session),
 ) -> ParseCatalogResponse:
     """Parse a catalog from an uploaded JSON file.
 
@@ -205,6 +206,8 @@ async def parse_catalog(
 
     except InvalidFileFormatError as e:
         log_secure_info("warning", f"Parse-catalog failed: job_id={job_id}, reason=invalid_file_format, status=400", job_id=job_id, end_section=True)
+        # Mark stage as failed since validation failed at API layer
+        mark_stage_as_failed(job_id, "parse-catalog", "INVALID_FILE_FORMAT", str(e), db_session)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
@@ -216,6 +219,8 @@ async def parse_catalog(
 
     except InvalidJSONError as e:
         log_secure_info("warning", f"Parse-catalog failed: job_id={job_id}, reason=invalid_json, status=400", job_id=job_id, end_section=True)
+        # Mark stage as failed since validation failed at API layer
+        mark_stage_as_failed(job_id, "parse-catalog", "INVALID_JSON", str(e), db_session)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={

--- a/build_stream/api/parse_catalog/routes.py
+++ b/build_stream/api/parse_catalog/routes.py
@@ -107,12 +107,6 @@ async def parse_catalog(
             f"filename={file.filename}, size_bytes={len(contents)}",
             job_id=job_id,
         )
-        log_secure_info(
-            "debug",
-            f"Parse-catalog executing: job_id={job_id}, "
-            f"filename={file.filename}, size_bytes={len(contents)}, content_type={file.content_type}",
-            job_id=job_id,
-        )
 
         # Create service with injected use case
         service = ParseCatalogService(parse_catalog_use_case=parse_catalog_use_case)

--- a/gitlab/roles/hosted_gitlab/files/.gitlab-ci.yml
+++ b/gitlab/roles/hosted_gitlab/files/.gitlab-ci.yml
@@ -1122,7 +1122,7 @@ summary:
             "build-image-aarch64": 4,
             "validate-image-on-test": 5
           };
-        
+
         # Sort stages by execution order, then by name
         .stages | sort_by([stage_order[.stage_name] // 999, .stage_name])[] |
         "  |    \(.stage_name): \(.stage_state)" +

--- a/gitlab/roles/hosted_gitlab/files/.gitlab-ci.yml
+++ b/gitlab/roles/hosted_gitlab/files/.gitlab-ci.yml
@@ -704,7 +704,7 @@ build-images:
       echo "============================================================"
       echo ""
 
-      echo "  Step 1/3: Retrieve catalog roles and image metadata..."
+      echo "  Step 1/2: Retrieve catalog roles and image metadata..."
       echo "  ------------------------------------------------------------"
       echo ""
       echo "  API Request:"
@@ -746,14 +746,27 @@ build-images:
       echo "  [OK] Roles retrieved successfully"
       echo ""
 
-      echo "  Step 2/3: Trigger image builds for each architecture..."
+      echo "  Step 2/2: Build images sequentially for each architecture..."
       echo "  ------------------------------------------------------------"
+      echo "  Strategy: Sequential execution with fail-fast behavior"
+      echo "  - Submit build for one architecture at a time"
+      echo "  - Wait for completion before starting the next"
+      echo "  - Exit immediately if any build fails"
+      echo ""
       BUILD_COUNT=0
 
       for ARCH in ${ARCHITECTURES}; do
         BUILD_COUNT=$((BUILD_COUNT + 1))
         echo ""
+        echo "  ============================================================"
         echo "  Build ${BUILD_COUNT}/${ARCH_COUNT}: ${ARCH}"
+        echo "  ============================================================"
+        echo ""
+
+        # Determine stage name for this architecture
+        STAGE_NAME="build-image-${ARCH}"
+
+        echo "  Step 2.${BUILD_COUNT}a: Submit build request for ${ARCH}..."
         echo "  ------------------------------------------------------------"
         echo ""
         echo "  API Request:"
@@ -781,7 +794,7 @@ build-images:
         echo ""
 
         if [ "$HTTP_CODE" != "202" ] && [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
-          echo "  ERROR: Build image failed for architecture ${ARCH}"
+          echo "  ERROR: Build image request failed for architecture ${ARCH}"
           echo "  Response Body:"
           jq '.' "build_response_${ARCH}.json" 2>/dev/null || cat "build_response_${ARCH}.json"
           exit 1
@@ -791,102 +804,94 @@ build-images:
         jq '.' "build_response_${ARCH}.json" 2>/dev/null || cat "build_response_${ARCH}.json"
         echo ""
         echo "  [OK] Build request accepted for ${ARCH}"
-      done
+        echo ""
 
-      echo ""
-      echo "  [OK] All ${BUILD_COUNT} build request(s) submitted successfully"
-      echo ""
+        echo "  Step 2.${BUILD_COUNT}b: Wait for ${ARCH} build to complete..."
+        echo "  ------------------------------------------------------------"
+        echo "  Polling interval: ${POLL_INTERVAL}s"
+        echo "  Max attempts: ${MAX_POLL_ATTEMPTS}"
+        echo "  Stage name: ${STAGE_NAME}"
+        echo ""
 
-      echo "  Step 3/3: Wait for all builds to complete..."
-      echo "  ------------------------------------------------------------"
-      echo "  Polling interval: ${POLL_INTERVAL}s"
-      echo "  Max attempts: ${MAX_POLL_ATTEMPTS}"
-      echo ""
+        TERMINAL_REACHED=false
+        ATTEMPT=1
 
-      TERMINAL_REACHED=false
-      ATTEMPT=1
+        while [ "$ATTEMPT" -le "$MAX_POLL_ATTEMPTS" ]; do
+          HTTP_CODE=$(api_call_with_retry "status_response_${ARCH}.json" \
+            -X GET "${BSM_API_URL}/api/v1/jobs/${JOB_ID}" \
+            --cacert "${BSM_CERT_FILE}")
+          [ -f /tmp/bsm_access_token ] && ACCESS_TOKEN=$(cat /tmp/bsm_access_token) && rm -f /tmp/bsm_access_token
 
-      while [ "$ATTEMPT" -le "$MAX_POLL_ATTEMPTS" ]; do
-        HTTP_CODE=$(api_call_with_retry status_response.json \
-          -X GET "${BSM_API_URL}/api/v1/jobs/${JOB_ID}" \
-          --cacert "${BSM_CERT_FILE}")
-        [ -f /tmp/bsm_access_token ] && ACCESS_TOKEN=$(cat /tmp/bsm_access_token) && rm -f /tmp/bsm_access_token
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "  [Poll ${ATTEMPT}/${MAX_POLL_ATTEMPTS}] HTTP ${HTTP_CODE} - retrying..."
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep "${POLL_INTERVAL}"
+            continue
+          fi
 
-        if [ "$HTTP_CODE" != "200" ]; then
-          echo "  [Poll ${ATTEMPT}/${MAX_POLL_ATTEMPTS}] HTTP ${HTTP_CODE} - retrying..."
+          # Get status of the specific stage for this architecture
+          STAGE_STATE=$(jq -r ".stages[]? | select(.stage_name == \"${STAGE_NAME}\") | .stage_state" \
+            "status_response_${ARCH}.json" 2>/dev/null || echo "UNKNOWN")
+          JOB_STATE=$(jq -r '.job_state // "UNKNOWN"' "status_response_${ARCH}.json")
+
+          echo "  [Poll ${ATTEMPT}/${MAX_POLL_ATTEMPTS}] Job: ${JOB_STATE} | Stage ${STAGE_NAME}: ${STAGE_STATE}"
+
+          # Check stage state
+          case "${STAGE_STATE}" in
+            COMPLETED|SUCCEEDED)
+              TERMINAL_REACHED=true
+              echo ""
+              echo "  Stage Details:"
+              jq ".stages[]? | select(.stage_name == \"${STAGE_NAME}\") |
+                {stage: .stage_name, state: .stage_state, started: .started_at, ended: .ended_at}" "status_response_${ARCH}.json" 2>/dev/null
+              echo ""
+              echo "  [OK] Build completed successfully for ${ARCH}"
+              break
+              ;;
+            FAILED|CANCELLED)
+              echo ""
+              echo "  ERROR: Build-image stage reached ${STAGE_STATE} for ${ARCH}"
+              echo "  Stage Details:"
+              jq ".stages[]? | select(.stage_name == \"${STAGE_NAME}\")" "status_response_${ARCH}.json" 2>/dev/null
+              echo ""
+              echo "  Stopping sequential build process (fail-fast)"
+              exit 1
+              ;;
+            PENDING|IN_PROGRESS|RUNNING)
+              # Still in progress, continue polling
+              ;;
+            *)
+              echo "  WARNING: Unexpected stage state: ${STAGE_STATE}"
+              ;;
+          esac
+
+          # Check job state for early failure detection
+          case "${JOB_STATE}" in
+            FAILED|CANCELLED)
+              echo ""
+              echo "  ERROR: Job reached ${JOB_STATE} state"
+              exit 1
+              ;;
+          esac
+
           ATTEMPT=$((ATTEMPT + 1))
           sleep "${POLL_INTERVAL}"
-          continue
+        done
+
+        if [ "$TERMINAL_REACHED" = "false" ]; then
+          echo ""
+          echo "  ERROR: Polling timed out for ${ARCH} after ${MAX_POLL_ATTEMPTS} attempts"
+          echo "  Last known stage state: ${STAGE_STATE}"
+          exit 1
         fi
 
-        BUILD_STAGES=$(jq -r '.stages[]? | select(.stage_name | startswith("build-image")) | .stage_state' status_response.json 2>/dev/null || echo "")
-        JOB_STATE=$(jq -r '.job_state // "UNKNOWN"' status_response.json)
-
-        BUILD_STATUS=$(jq -r '[.stages[]? | select(.stage_name | startswith("build-image")) |
-          "\(.stage_name | split("-") | last)=\(.stage_state)"] | join(", ")' status_response.json 2>/dev/null || echo "N/A")
-
-        echo "  [Poll ${ATTEMPT}/${MAX_POLL_ATTEMPTS}] Job: ${JOB_STATE} | Builds: ${BUILD_STATUS}"
-
-        if [ -n "${BUILD_STAGES}" ]; then
-          ALL_COMPLETED=true
-          for STAGE_STATE in ${BUILD_STAGES}; do
-            case "${STAGE_STATE}" in
-              COMPLETED|SUCCEEDED)
-                ;;
-              FAILED|CANCELLED)
-                echo ""
-                echo "  ERROR: Build-image stage reached ${STAGE_STATE}"
-                echo "  Build Stage Details:"
-                jq '.stages[]? | select(.stage_name | startswith("build-image"))' status_response.json 2>/dev/null
-                exit 1
-                ;;
-              *)
-                ALL_COMPLETED=false
-                break
-                ;;
-            esac
-          done
-
-          if [ "$ALL_COMPLETED" = "true" ]; then
-            TERMINAL_REACHED=true
-            echo ""
-            echo "  Final Build Status:"
-            jq '.stages[]? | select(.stage_name | startswith("build-image")) |
-              {stage: .stage_name, state: .stage_state, started: .started_at, ended: .ended_at}' status_response.json 2>/dev/null
-            break
-          fi
-        fi
-
-        case "${JOB_STATE}" in
-          FAILED|CANCELLED)
-            echo ""
-            echo "  ERROR: Job reached ${JOB_STATE} state"
-            exit 1
-            ;;
-          SUCCEEDED|COMPLETED)
-            TERMINAL_REACHED=true
-            break
-            ;;
-        esac
-
-        ATTEMPT=$((ATTEMPT + 1))
-        sleep "${POLL_INTERVAL}"
+        echo ""
       done
 
-      if [ "$TERMINAL_REACHED" = "false" ]; then
-        echo ""
-        echo "  ERROR: Polling timed out after ${MAX_POLL_ATTEMPTS} attempts"
-        exit 1
-      fi
-
-      if [ "$JOB_STATE" = "FAILED" ]; then
-        echo ""
-        echo "  ERROR: Job ended in FAILED state"
-        exit 1
-      fi
-
       echo ""
-      echo "  [OK] All images built successfully"
+      echo "  ============================================================"
+      echo "  [OK] All ${BUILD_COUNT} image(s) built successfully"
+      echo "  ============================================================"
   artifacts:
     paths:
       - roles_response.json

--- a/gitlab/roles/hosted_gitlab/files/.gitlab-ci.yml
+++ b/gitlab/roles/hosted_gitlab/files/.gitlab-ci.yml
@@ -1110,9 +1110,24 @@ summary:
       echo "  +-----------------------------------------------------------+"
       echo "  |  Stage Results:                                           |"
 
-      jq -r '.stages[]? | "  |    \(.stage_name): \(.stage_state)" +
-               (if .error_code then "  [\(.error_code)]" else "" end)' \
-        final_status.json 2>/dev/null || echo "  |    (no stage data)"
+      # Sort stages in chronological execution order
+      jq -r '
+        # Define stage execution order
+        def stage_order:
+          {
+            "parse-catalog": 1,
+            "generate-input-files": 2,
+            "create-local-repository": 3,
+            "build-image-x86_64": 4,
+            "build-image-aarch64": 4,
+            "validate-image-on-test": 5
+          };
+        
+        # Sort stages by execution order, then by name
+        .stages | sort_by([stage_order[.stage_name] // 999, .stage_name])[] |
+        "  |    \(.stage_name): \(.stage_state)" +
+        (if .error_code then "  [\(.error_code)]" else "" end)
+      ' final_status.json 2>/dev/null || echo "  |    (no stage data)"
 
       echo "  +-----------------------------------------------------------+"
 


### PR DESCRIPTION


### Description of the Solution
- Add mark_stage_as_failed helper function to update stage state in database
- Update parse-catalog endpoint to mark stage as FAILED for invalid JSON/file format
- Update generate-input-files endpoint to mark stage as FAILED for invalid policy path
- Fix database transaction commit to ensure stage state is persisted
- This prevents stages from remaining stuck in PENDING state when validation fails at API layer
 
Fixes issue where parse-catalog stage remained PENDING after invalid JSON error

### Suggested Reviewers
If you wish to suggest specific reviewers for this solution, please include them in this section. Be sure to include the _@_ before the GitHub username.
@priti-parate @abhishek-sa1 @Venu-p1 