### PR TITLE
Fix: Add missing additional_json_path parameter for aarch64 build image playbook

### DIFF
--- a/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
+++ b/build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml
@@ -53,6 +53,7 @@
         functional_groups: "{{ functional_group_list }}"
         software_config_file: "{{ software_config_file_path }}"
         input_project_dir: "{{ input_project_dir }}"
+        additional_json_path: "{{ additional_json_path }}"
       register: compute_images_output
 
     - name: Save packages for aarch64 keys in compute_images_dict


### PR DESCRIPTION
## Issue
The 'build_image_aarch64' playbook was not including additional packages from 'additional_packages.json' for compute image roles (slurm_node, login_node, login_compiler_node). Only the base image packages were being added.
 
## Root Cause
The 'image_package_collector' task in 'build_image_aarch64/roles/fetch_packages/tasks/fetch_packages.yml' was missing the 'additional_json_path' parameter, which is required to read and include packages from the additional_packages.json file.
 
This parameter was present in the x86_64 equivalent but was omitted during the aarch64 implementation.
 
## Fix
Added the missing 'additional_json_path: "{{ additional_json_path }}"' parameter to the 'image_package_collector' task in the aarch64 fetch_packages.yml file.

@abhishek-sa1 Please review
 